### PR TITLE
Fix: gracefully handle slow-loading Alpine

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -3,15 +3,19 @@ import { waitForAlpine, set } from './utils';
 window.addEventListener("message", handshake);
 window.__alpineDevtool = {};
 
+function startAlpineBackend() {
+    getAlpineVersion();
+    discoverComponents();
+
+    document.querySelectorAll("[x-data]").forEach((el) => observeNode(el));
+}
+
 function handshake(e) {
     if (e.data.source === "alpine-devtools-proxy" && e.data.payload === "init") {
         window.removeEventListener("message", handshake);
         window.addEventListener("message", handleMessages);
 
-        getAlpineVersion();
-        discoverComponents();
-
-        document.querySelectorAll("[x-data]").forEach((el) => observeNode(el));
+        waitForAlpine(() => startAlpineBackend());
     }
 }
 
@@ -86,7 +90,7 @@ function getComponentName(element) {
     if (element.id) {
         return element.id
     }
-    
+
     const nameAttr = element.getAttribute('name');
     if (nameAttr) {
         return nameAttr
@@ -108,7 +112,7 @@ function getComponentName(element) {
     if (xDataAttr.endsWith(")") && !xDataAttr.startsWith("{")) {
         return xDataAttr.split('(')[0]
     }
-    
+
     const roleAttr = element.getAttribute('role');
     if (roleAttr) {
         return roleAttr;

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -1,19 +1,4 @@
-/**
-* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
-*
-* @param {object} object - object to update
-* @param {string} path - path to set in the form `a.0.b.c`
-* @param {any} value - value to set to
-*/
-function set(object, path, value) {
-    const [nextProperty, ...rest] = path.split('.');
-    if (rest.length === 0) {
-        object[nextProperty] = value;
-        return object;
-    }
-    set(object[nextProperty], rest.join('.'), value);
-    return object
-}
+import { waitForAlpine, set } from './utils';
 
 window.addEventListener("message", handshake);
 window.__alpineDevtool = {};

--- a/packages/shell-chrome/src/detector.js
+++ b/packages/shell-chrome/src/detector.js
@@ -1,4 +1,5 @@
 import { isFirefox } from './env';
+import { waitForAlpine } from './utils';
 
 window.addEventListener('message', e => {
   if (e.source === window && e.data.alpineDetected) {
@@ -6,12 +7,12 @@ window.addEventListener('message', e => {
   }
 })
 
-function detect (win) {
-  setTimeout(() => {
-    win.postMessage({
-      alpineDetected: !!window.Alpine
-    })
-  }, 100)
+function detect(win) {
+    waitForAlpine(() => {
+        win.postMessage({
+            alpineDetected: !!window.Alpine
+        })
+    }, { maxAttempts: 3, interval: 250, delayFirstAttempt: true })
 }
 
 // inject the hook

--- a/packages/shell-chrome/src/detector.js
+++ b/packages/shell-chrome/src/detector.js
@@ -6,7 +6,7 @@ window.addEventListener('message', e => {
   }
 })
 
-// will detect Alpine.js as long as it loads within ~600ms
+// will detect Alpine.js as long as it loads within ~600ms of the script being injected
 function detect(win, remainingAttempts = 3) {
     setTimeout(() => {
         const alpineDetected = !!window.Alpine

--- a/packages/shell-chrome/src/detector.js
+++ b/packages/shell-chrome/src/detector.js
@@ -1,5 +1,4 @@
 import { isFirefox } from './env';
-import { waitForAlpine } from './utils';
 
 window.addEventListener('message', e => {
   if (e.source === window && e.data.alpineDetected) {
@@ -7,12 +6,17 @@ window.addEventListener('message', e => {
   }
 })
 
-function detect(win) {
-    waitForAlpine(() => {
+// will detect Alpine.js as long as it loads within ~600ms
+function detect(win, remainingAttempts = 3) {
+    setTimeout(() => {
+        const alpineDetected = !!window.Alpine
         win.postMessage({
-            alpineDetected: !!window.Alpine
+            alpineDetected
         })
-    }, { maxAttempts: 3, interval: 250, delayFirstAttempt: true })
+        if (!alpineDetected && remainingAttempts > 0) {
+            detect(win, remainingAttempts - 1);
+        }
+    }, 200)
 }
 
 // inject the hook

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -2,7 +2,7 @@ export function fetchWithTimeout(resource, options) {
     const { timeout = 3000 } = options;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeout);
-    return fetch(resource, {...options, signal: controller.signal}).then((res) => {
+    return fetch(resource, { ...options, signal: controller.signal }).then((res) => {
         clearTimeout(timer);
         if (!res.ok) {
             throw new Error('Request not ok');
@@ -22,12 +22,12 @@ export function flattenData(data) {
 }
 
 /**
-* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
-*
-* @param {object} object - object to update
-* @param {string} path - path to set in the form `a.0.b.c`
-* @param {any} value - value to set to
-*/
+ * Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
+ *
+ * @param {object} object - object to update
+ * @param {string} path - path to set in the form `a.0.b.c`
+ * @param {any} value - value to set to
+ */
 export function set(object, path, value) {
     const [nextProperty, ...rest] = path.split('.');
     if (rest.length === 0) {
@@ -38,7 +38,9 @@ export function set(object, path, value) {
     return object
 }
 
-export function waitForAlpine(cb, {maxAttempts = 3, interval = 500, delayFirstAttempt = false } = {}) {
+// with default options, will run 3 attempts, 1 at 0s, 1 at 500ms, 1 at 1000ms
+// so should hook into Alpine.js if it loads within 1s of the script triggering
+export function waitForAlpine(cb, { maxAttempts = 3, interval = 500, delayFirstAttempt = false } = {}) {
     let attempts = delayFirstAttempt ? 0 : 1;
     if (!delayFirstAttempt && window.Alpine) {
         console.info(`waitForAlpine, attempts: ${attempts}/${maxAttempts}`);

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -25,9 +25,9 @@ export function set(object, path, value) {
     return object
 }
 
-export function waitForAlpine(cb, {maxAttempts = 3, interval = 500 } = {}) {
-    let attempts = 1;
-    if (window.Alpine) {
+export function waitForAlpine(cb, {maxAttempts = 3, interval = 500, delayFirstAttempt = false } = {}) {
+    let attempts = delayFirstAttempt ? 0 : 1;
+    if (!delayFirstAttempt && window.Alpine) {
         console.info(`waitForAlpine, attempts: ${attempts}/${maxAttempts}`);
         cb();
         return;

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -32,6 +32,7 @@ export function waitForAlpine(cb, {maxAttempts = 3, interval = 500, delayFirstAt
         cb();
         return;
     }
+    if (attempts >= maxAttempts) return
     const timer = setInterval(wait, interval);
     function wait() {
         attempts++;

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -8,6 +8,43 @@ export function flattenData(data) {
     return flattenedData;
 }
 
+/**
+* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
+*
+* @param {object} object - object to update
+* @param {string} path - path to set in the form `a.0.b.c`
+* @param {any} value - value to set to
+*/
+export function set(object, path, value) {
+    const [nextProperty, ...rest] = path.split('.');
+    if (rest.length === 0) {
+        object[nextProperty] = value;
+        return object;
+    }
+    set(object[nextProperty], rest.join('.'), value);
+    return object
+}
+
+export function waitForAlpine(cb, {maxAttempts = 3, interval = 500 } = {}) {
+    let attempts = 1;
+    if (window.Alpine) {
+        console.info(`waitForAlpine, attempts: ${attempts}/${maxAttempts}`);
+        cb();
+        return;
+    }
+    const timer = setInterval(wait, interval);
+    function wait() {
+        attempts++;
+        console.info(`waitForAlpine, attempts: ${attempts}/${maxAttempts}`);
+        if (attempts >= maxAttempts || window.Alpine) {
+            clearInterval(timer);
+        }
+        if (window.Alpine) {
+            cb();
+        }
+    }
+}
+
 function mapDataTypeToInputType(dataType) {
     switch (dataType) {
         case 'boolean':

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,45 +12,57 @@ if (process.env.ROLLUP_WATCH === 'true') {
         try {
             console.info(`Copying asset "${filename}" to dist/chrome`);
             fs.copyFileSync(path.join('./packages/shell-chrome/assets/', filename), path.join('./dist/chrome', filename));
-        } catch(e) {
+        } catch (e) {
             console.error(e);
         }
     });
 }
 
-export default {
-    input: [
-        'packages/shell-chrome/src/background.js',
-        'packages/shell-chrome/src/devtools-background.js',
-        'packages/shell-chrome/src/backend.js',
-        'packages/shell-chrome/src/panel.js',
-        'packages/shell-chrome/src/proxy.js',
-        'packages/shell-chrome/src/detector.js',
-    ],
-    output: {
-        dir: 'dist/chrome'
-    },
-    plugins: [
-        resolve(),
-        postcss({
-            extract: 'styles.css',
-        }),
-        copy({
-            targets: [
-                {
-                    src: 'packages/shell-chrome/assets/**/*',
-                    dest: 'dist/chrome',
-                },
-                {
-                    src: 'packages/shell-chrome/assets/manifest.json',
-                    dest: 'dist/chrome',
-                    // inject version into manifest
-                    transform(contents) {
-                        return contents.toString().replace('__version__', pkg.version)
+export default [
+    {
+        input: [
+            'packages/shell-chrome/src/background.js',
+            'packages/shell-chrome/src/devtools-background.js',
+            'packages/shell-chrome/src/panel.js',
+            'packages/shell-chrome/src/proxy.js',
+            'packages/shell-chrome/src/detector.js',
+        ],
+        output: {
+            dir: 'dist/chrome'
+        },
+        plugins: [
+            resolve(),
+            postcss({
+                extract: 'styles.css',
+            }),
+            copy({
+                targets: [
+                    {
+                        src: 'packages/shell-chrome/assets/**/*',
+                        dest: 'dist/chrome',
+                    },
+                    {
+                        src: 'packages/shell-chrome/assets/manifest.json',
+                        dest: 'dist/chrome',
+                        // inject version into manifest
+                        transform(contents) {
+                            return contents.toString().replace('__version__', pkg.version)
+                        }
                     }
-                }
-            ]
-        }),
-        filesize(),
-    ],
-}
+                ]
+            }),
+            filesize(),
+        ],
+    },
+    {
+        // separate out otherwise rollup tries to create a common "utils" chunk
+        input: 'packages/shell-chrome/src/backend.js',
+        output: {
+            dir: 'dist/chrome'
+        },
+        plugins: [
+            resolve(),
+            filesize(),
+        ]
+    }
+]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,15 +18,31 @@ if (process.env.ROLLUP_WATCH === 'true') {
     });
 }
 
+const JS_INPUTS = [
+    'packages/shell-chrome/src/background.js',
+    'packages/shell-chrome/src/devtools-background.js',
+    'packages/shell-chrome/src/proxy.js',
+    'packages/shell-chrome/src/detector.js',
+]
+
+const MIXED_INPUT = [
+    'packages/shell-chrome/src/panel.js',
+]
+
 export default [
-    {
-        input: [
-            'packages/shell-chrome/src/background.js',
-            'packages/shell-chrome/src/devtools-background.js',
-            'packages/shell-chrome/src/panel.js',
-            'packages/shell-chrome/src/proxy.js',
-            'packages/shell-chrome/src/detector.js',
-        ],
+    // create standalone builds to avoid rollup creating a common "utils" chunk
+    ...JS_INPUTS.map((input) => ({
+        input,
+        output: {
+            dir: 'dist/chrome'
+        },
+        plugins: [
+            resolve(),
+            filesize()
+        ]
+    })),
+    ...MIXED_INPUT.map((input) => ({
+        input,
         output: {
             dir: 'dist/chrome'
         },
@@ -53,16 +69,5 @@ export default [
             }),
             filesize(),
         ],
-    },
-    {
-        // separate out otherwise rollup tries to create a common "utils" chunk
-        input: 'packages/shell-chrome/src/backend.js',
-        output: {
-            dir: 'dist/chrome'
-        },
-        plugins: [
-            resolve(),
-            filesize(),
-        ]
-    }
+    }))
 ]


### PR DESCRIPTION
Improve situations where the script would kick in before Alpine.js has finished loading:

- on page reload, should be fine as long as Alpine.js loads within 1s of the script initialising (and removes a cannot read property `version` of undefined due to `window.Alpine.version` triggering early)
- for Alpine.js detection (toolbar icon), run a few attempts (will detect Alpine as long as it loads within 400ms of the script)
- refactor rollup config so that each file gets its own bundle (no shared chunks) -> means we can extract some utils out of the backend.js file.