### PR TITLE
Improve GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,4 @@ jobs:
       with:
         start: npm start
         command: npm run cy:run
+        install: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: pull_request
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,16 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Apply formatting changes
-    - name: Cypress run
-      uses: cypress-io/github-action@v2
+    # see https://github.com/bahmutov/cypress-gh-action-split-install
+    - run: npx cypress cache path && npx cypress cache list
+    # restore / cache the binary ourselves on Linux
+    # see https://github.com/actions/cache
+    - name: Cache Cypress
+      id: cache-cypress
+      uses: actions/cache@v1
       with:
-        start: npm start
-        command: npm run cy:run
-        install: false
+        path: ~/.cache/Cypress
+        key: cypress-cache-v1-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+    # install Cypress binary
+    - run: npx cypress install && npx cypress cache list
+    - run: npm run cy:run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,8 @@ jobs:
         key: cypress-cache-v1-${{ runner.os }}-${{ hashFiles('**/package.json') }}
     # install Cypress binary
     - run: npx cypress install && npx cypress cache list
-    - run: npm run cy:run
+    - uses: cypress-io/github-action@v2
+      with:
+        start: npm start
+        command: npm run cy:run
+        install: false


### PR DESCRIPTION
- run GitHub Actions on PR and master push
- skip Cypress `npm i` (we already have the node_modules, just need the Cypress binary)