### PR TITLE
[wip] support nested HTMLElements

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -87,6 +87,49 @@ function handleMessages(e) {
     }
 }
 
+function serializeDataProperty(value) {
+    if (value instanceof HTMLElement) {
+        return {
+            value: serializeHTMLElement(value),
+            type: 'HTMLElement',
+            __gen: true,
+        }
+    }
+    const typeOfValue = typeof value
+    if (typeOfValue === 'function') {
+        return {
+            value: 'function',
+            type: 'function',
+            __gen: true,
+        }
+    }
+    if (Array.isArray(value)) {
+        return {
+            value: value.map((item) => serializeDataProperty(item)),
+            type: typeOfValue,
+            __gen: true,
+        }
+    }
+    if (typeOfValue === 'object') {
+        return {
+            value: Object.fromEntries(
+                Object.entries(value).map(([propertyName, propertyValue]) => [
+                    propertyName,
+                    serializeDataProperty(propertyValue),
+                ]),
+            ),
+            type: typeOfValue,
+            __gen: true,
+        }
+    }
+
+    return {
+        value: value,
+        type: typeOfValue,
+        __gen: true,
+    }
+}
+
 function discoverComponents(isThroughMutation = false) {
     var rootEls = document.querySelectorAll('[x-data]')
 
@@ -118,15 +161,7 @@ function discoverComponents(isThroughMutation = false) {
         }
 
         const data = Object.entries(rootEl.__x.getUnobservedData()).reduce((acc, [key, value]) => {
-            acc[key] = {
-                value:
-                    value instanceof HTMLElement
-                        ? serializeHTMLElement(value)
-                        : typeof value === 'function'
-                        ? 'function'
-                        : value,
-                type: value instanceof HTMLElement ? 'HTMLElement' : typeof value,
-            }
+            acc[key] = serializeDataProperty(value)
             return acc
         }, {})
 

--- a/packages/simulator/example.html
+++ b/packages/simulator/example.html
@@ -11,7 +11,16 @@
 
     <body>
         <div
-            x-data="{ el: $el, myFunction() { return true }, bool: true, num: 5, str: 'string', arr: ['world', 'bar'], nested: {array: [ { hello: 'world' }]}}"
+            x-data="{
+                el: $el,
+                els: [$el],
+                nested: { el: $el, nestedFn() {}, array: [ { hello: 'world' }] },
+                myFunction() { return true },
+                bool: true,
+                num: 5,
+                str: 'string',
+                arr: ['world', 'bar']
+            }"
         >
             <div>Bool, type: "<span x-text="typeof bool"></span>", value: "<span x-text="bool"></span>"</div>
             <div>Num, type: "<span x-text="typeof num"></span>", value: "<span x-text="num"></span>"</div>
@@ -23,8 +32,8 @@
                 >"
             </div>
             <div>
-                Nested, type "<span x-text="typeof nested"></span>, value (stringified): "<span
-                    x-text="JSON.stringify(nested)"
+                Nested array, type "<span x-text="typeof nested.array"></span>, value (stringified): "<span
+                    x-text="JSON.stringify(nested.array)"
                 ></span
                 >"
             </div>


### PR DESCRIPTION
Closes #96 

Happy for someone else to PR into this branch.

**Todo**

- [x] walk the values when being serialized, generate `type`/`value` and mark the object as generated (with `__gen: true`)
- [ ] [WIP] when receiving the values remove the `type`/`value` nesting to display fields correctly
- [x] add test cases to simulator/example.html `x-data` (`els: [$el], nested: { el: $el, fn() {} }`)
- [ ] add E2E (Cypress) test for nested HTMLElement/functions
- [ ] (maybe) add unit tests + refactor the whole `flattenData` thing 😄 (take some sample input/output in the simulator on `master` and rewrite the function)