### PR TITLE
perf: only include top-level children of HTMLElement

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -121,7 +121,7 @@ function discoverComponents(isThroughMutation = false) {
             acc[key] = {
                 value:
                     value instanceof HTMLElement
-                        ? serializeHTMLElement(value)
+                        ? serializeHTMLElement(value, { include: ['children', 'attributes'] })
                         : typeof value === 'function'
                         ? 'function'
                         : value,

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -98,23 +98,25 @@ function getAttributeValue(value, type) {
     return value
 }
 
-// Thank you! https://stackoverflow.com/a/54273003/1437789
-// modified for perf reasons, we don't want to get the full DOM tree of descendents
+/**
+ *
+ * Serialize HTMLElement to an object with name, attributes & direct descendents
+ *
+ * @param {HTMLElement} element
+ * @param {object} options
+ * @param {Array<'attributes'|'children'>} options.include
+ * @returns {{name: string, attributes?: Array<string>, children?: Array<string>}}
+ */
 export function serializeHTMLElement(element, { include = [] } = {}) {
     let object = { name: element.localName }
     if (include.includes('attributes')) {
-        object.attributes = Array.from(element.attributes).map((attribute) => ({
-            name: attribute.name,
-            value: attribute.value,
-        }))
+        object.attributes = Array.from(element.attributes).map((attribute) => attribute.name)
     }
     // `include` is used to avoid getting the children of children.
     // For the top-level iteration, children are included,
     // in the recursive case they're not
     if (include.includes('children')) {
-        object.children = Array.from(element.children).map((child) =>
-            serializeHTMLElement(child, { include: ['attributes'] }),
-        )
+        object.children = Array.from(element.children).map((child) => serializeHTMLElement(child).name)
     }
 
     return object


### PR DESCRIPTION
For perf reasons, it's not ideal to be passing the whole tree of DOM children of an element to the devtools.

Instead pass the first-level children with their attributes and ignore any further children.

We could maybe re-introduce the full DOM walk once we do partial loading of data as part of #10 

Couple of questions for @KevinBatdorf:
- first of all -> thoughts on this PR?
- further improvements
  - should we return the children name instead of name + attributes?
  - should we be truncating attribute values? eg. if an element had `x-data` + `x-init` that's a bunch of text that's not necessarily super useful

Note: once this gets merged it'll probably be a good time to roll out `0.0.8` 👍 