### PR TITLE
Fix resize pane init

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
         }
     },
     "lint-staged": {
-        "*.{js,css,md}": "prettier --write"
+        "*.{js,css,md,html}": "prettier --write"
     }
 }

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -52,6 +52,10 @@ export default function devtools() {
             return isRequiredVersion(this.latest, this.version)
         },
 
+        get isLandscape() {
+            return this.orientation === 'landscape'
+        },
+
         get detected() {
             if (!this.showTools) {
                 return 'Alpine.js tools loading'
@@ -102,10 +106,10 @@ export default function devtools() {
             }
 
             const splitOptions = {
-                minSize: this.orientation === 'landscape' ? 250 : 150,
+                minSize: this.isLandscape ? 250 : 150,
                 snapOffset: 0,
             }
-            const key = this.orientation === 'landscape' ? 'columnGutters' : 'rowGutters'
+            const key = this.isLandscape ? 'columnGutters' : 'rowGutters'
 
             splitOptions[key] = [
                 {

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -20,6 +20,19 @@ const themes = {
     },
 }
 
+const breakpoint = 640
+
+let width = window.innerWidth
+const isLargerThanBreakpoint = (minWidth) => {
+    const newWidth = window.innerWidth
+    // when hiding the devtools tab, innerWidth goes to 0
+    // resume using last known size
+    width = newWidth === 0 ? width : newWidth
+    return width > minWidth
+}
+
+const getOrientation = () => (isLargerThanBreakpoint(breakpoint) ? 'landscape' : 'portrait')
+
 export default function devtools() {
     return {
         version: null,
@@ -29,8 +42,7 @@ export default function devtools() {
         showTimeout: 1500,
         activeTheme: 'dark-header',
 
-        orientation: 'portrait',
-        breakpoint: 640,
+        orientation: getOrientation(),
         split: null,
 
         themes: themes,
@@ -60,12 +72,8 @@ export default function devtools() {
             return this.themes[this.activeTheme]
         },
 
-        updateOrientation() {
-            this.orientation = window.innerWidth > this.breakpoint ? 'landscape' : 'portrait'
-        },
-
         init() {
-            this.initLayout()
+            this.initSplitPanes()
             this.$watch('components', () => {
                 if (!this.showTools && this.components.length > 0) {
                     fetchWithTimeout('https://registry.npmjs.com/alpinejs', { timeout: this.showTimeout })
@@ -94,10 +102,10 @@ export default function devtools() {
             }
 
             const splitOptions = {
-                minSize: window.innerWidth > this.breakpoint ? 250 : 150,
+                minSize: this.orientation === 'landscape' ? 250 : 150,
                 snapOffset: 0,
             }
-            const key = window.innerWidth > this.breakpoint ? 'columnGutters' : 'rowGutters'
+            const key = this.orientation === 'landscape' ? 'columnGutters' : 'rowGutters'
 
             splitOptions[key] = [
                 {
@@ -111,14 +119,11 @@ export default function devtools() {
             })
         },
 
-        initLayout() {
-            this.initSplitPanes()
-            this.updateOrientation()
-        },
-
         devtoolsRootDirectives() {
             return {
-                ['@resize.window.debounce.100']: this.initLayout,
+                ['@resize.window.debounce.100']() {
+                    this.orientation = getOrientation()
+                },
             }
         },
     }

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -65,28 +65,25 @@ export default function devtools() {
         },
 
         init() {
-            return () => {
-                this.initLayout()
+            this.initLayout()
+            this.$watch('components', () => {
+                if (!this.showTools && this.components.length > 0) {
+                    fetchWithTimeout('https://registry.npmjs.com/alpinejs', { timeout: this.showTimeout })
+                        .then((data) => {
+                            this.latest = data['dist-tags'].latest
+                            this.showTools = true
+                        })
+                        .catch((_error) => {
+                            console.error('Could not load Alpine.js version data from registry.npmjs.com')
+                            // latest will be as defaulted in state.js
+                            this.showTools = true
+                        })
+                }
+            })
 
-                this.$watch('components', () => {
-                    if (!this.showTools && this.components.length > 0) {
-                        fetchWithTimeout('https://registry.npmjs.com/alpinejs', { timeout: this.showTimeout })
-                            .then((data) => {
-                                this.latest = data['dist-tags'].latest
-                                this.showTools = true
-                            })
-                            .catch((_error) => {
-                                console.error('Could not load Alpine.js version data from registry.npmjs.com')
-                                // latest will be as defaulted in state.js
-                                this.showTools = true
-                            })
-                    }
-                })
-
-                this.$watch('orientation', () => {
-                    this.initSplitPanes()
-                })
-            }
+            this.$watch('orientation', () => {
+                this.initSplitPanes()
+            })
         },
 
         initSplitPanes() {


### PR DESCRIPTION
- when hiding the devtools tab, width of the panel window goes to 0 cache window size and when window width is 0, use cached value

Fixes the following issue:
![Kapture 2020-12-05 at 18 17 40](https://user-images.githubusercontent.com/6459679/101261018-e16bec80-372b-11eb-9452-a5b804d86c5b.gif)

