### PR TITLE
add tests for boolean, number and string editing

### DIFF
--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -10,8 +10,6 @@ it('should get names of components', () => {
 })
 
 it('should add/remove hover overlay on component mouseenter/leave', () => {
-    cy.visit('/')
-
     // check overlay works for first component
     cy.get('[data-testid=component-container]').first().should('be.visible').trigger('mouseenter')
 
@@ -86,12 +84,11 @@ it('should add/remove hover overlay on component mouseenter/leave', () => {
     })
     cy.iframe('#target').find('[data-testid=hover-element]').should('not.exist')
 })
+it('should support selecting a component', () => {
+    cy.visit('/').get('[data-testid=component-container]').first().should('be.visible').click()
+})
 
-it('should allow display read-only function/HTMLElement attributes', () => {
-    cy.visit('/')
-
-    cy.get('[data-testid=component-container]').first().should('be.visible').click()
-
+it('should display read-only function/HTMLElement attributes', () => {
     cy.get('[data-testid=data-property-name]')
         .should('be.visible')
         .contains('myFunction')
@@ -134,4 +131,62 @@ it('should allow display read-only function/HTMLElement attributes', () => {
         .should('not.be.visible')
         .get('@elChildren')
         .should('not.be.visible')
+})
+
+it('should allow editing of booleans, numbers and strings', () => {
+    // booleans
+    cy.get('[data-testid=data-property-name]')
+        .should('be.visible')
+        .contains('bool')
+        .siblings('[data-testid=data-property-value-container]')
+        .should('contain.text', 'true')
+    // checkbox is visibility is toggled using CSS click the hidden element
+    cy.get('[type=checkbox]').click({ force: true })
+    // check the edit worked
+    cy.get('[data-testid=data-property-name]')
+        .should('be.visible')
+        .contains('bool')
+        .siblings('[data-testid=data-property-value-container]')
+        .should('contain.text', 'false')
+    cy.iframe('#target').contains('Bool, type: "boolean", value: "false"')
+
+    // numbers
+    cy.get('[data-testid=data-property-name]')
+        .should('be.visible')
+        .contains('num')
+        .siblings('[data-testid=data-property-value-container]')
+        .should('contain.text', '5')
+
+    // edit icon visibility is toggled using CSS, force-click
+    cy.get('[data-testid=edit-icon-num]').click({ force: true })
+
+    // editing toggles alpineState, this causes issues with visibility/re-rendering
+    // force all interaction
+    cy.get('[data-testid=input-num]')
+        .clear({ force: true })
+        .type('20', { force: true })
+        .siblings('[data-testid=save-icon]')
+        .click({ force: true })
+
+    cy.iframe('#target').contains('Num, type: "number", value: "20"')
+
+    // numbers
+    cy.get('[data-testid=data-property-name]')
+        .should('be.visible')
+        .contains('str')
+        .siblings('[data-testid=data-property-value-container]')
+        .should('contain.text', 'string')
+
+    // edit icon visibility is toggled using CSS, force-click
+    cy.get('[data-testid=edit-icon-str]').click({ force: true })
+
+    // editing toggles alpineState, this causes issues with visibility/re-rendering
+    // force all interaction
+    cy.get('[data-testid=input-str]')
+        .clear({ force: true })
+        .type('devtools', { force: true })
+        .siblings('[data-testid=save-icon]')
+        .click({ force: true })
+
+    cy.iframe('#target').contains('Str, type: "string", value: "devtools"')
 })

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -156,12 +156,10 @@ it('should allow editing of booleans, numbers and strings', () => {
         .contains('num')
         .siblings('[data-testid=data-property-value-container]')
         .should('contain.text', '5')
-
     // edit icon visibility is toggled using CSS, force-click
     cy.get('[data-testid=edit-icon-num]').click({ force: true })
-
-    // editing toggles alpineState, this causes issues with visibility/re-rendering
-    // force all interaction
+    // editing toggles window.alpineState, causes issues with visibility/re-rendering
+    // force all interactions
     cy.get('[data-testid=input-num]')
         .clear({ force: true })
         .type('20', { force: true })
@@ -170,18 +168,16 @@ it('should allow editing of booleans, numbers and strings', () => {
 
     cy.iframe('#target').contains('Num, type: "number", value: "20"')
 
-    // numbers
+    // strings
     cy.get('[data-testid=data-property-name]')
         .should('be.visible')
         .contains('str')
         .siblings('[data-testid=data-property-value-container]')
         .should('contain.text', 'string')
-
     // edit icon visibility is toggled using CSS, force-click
     cy.get('[data-testid=edit-icon-str]').click({ force: true })
-
-    // editing toggles alpineState, this causes issues with visibility/re-rendering
-    // force all interaction
+    // editing toggles window.alpineState, causes issues with visibility/re-rendering
+    // force all interactions
     cy.get('[data-testid=input-str]')
         .clear({ force: true })
         .type('devtools', { force: true })

--- a/packages/shell-chrome/assets/panel.html
+++ b/packages/shell-chrome/assets/panel.html
@@ -306,7 +306,7 @@
                                                             class="text-black ml-1"
                                                             x-show="!singleData.inEditingMode"
                                                         >
-                                                            <template x-if="singleData.dataType == 'string'">
+                                                            <template x-if="singleData.dataType === 'string'">
                                                                 &quot;<span
                                                                     class="text-red-700"
                                                                     x-text="singleData.attributeValue"
@@ -314,7 +314,7 @@
                                                                 >&quot;
                                                             </template>
 
-                                                            <template x-if="singleData.dataType == 'boolean'">
+                                                            <template x-if="singleData.dataType === 'boolean'">
                                                                 <span
                                                                     class="text-blue-700"
                                                                     x-text="singleData.attributeValue"
@@ -340,7 +340,7 @@
                                                         fill="currentColor"
                                                         x-show="!singleData.inEditingMode
                                                         && singleData.dataType !== 'boolean'"
-                                                        data-testid="edit-icon"
+                                                        :data-testid="`edit-icon-${singleData.attributeName}`"
                                                         @click="alpineState.editAttribute(singleData)"
                                                         viewBox="0 0 20 20"
                                                         class="w-4 h-4 cursor-pointer opacity-0 group-hover:opacity-100 hover:opacity-75"
@@ -350,7 +350,7 @@
                                                         ></path>
                                                     </svg>
 
-                                                    <template x-if="singleData.dataType == 'boolean'">
+                                                    <template x-if="singleData.dataType === 'boolean'">
                                                         <input
                                                             type="checkbox"
                                                             x-model="singleData.editAttributeValue"
@@ -368,7 +368,8 @@
                                                                 @keydown.enter.stop="alpineState.saveEditing(singleData)"
                                                                 @keydown.escape.stop="alpineState.cancelEditing(singleData)"
                                                                 class="flex text-gray-700 leading-tight focus:outline-none focus:shadow-outline w-2/3 shadow appearance-none border rounded py-1 px-1"
-                                                                :type="singleData.dataType"
+                                                                :type="singleData.inputType"
+                                                                :data-testid="`input-${singleData.attributeName}`"
                                                                 x-model="singleData.editAttributeValue"
                                                             />
 

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -53,10 +53,9 @@ export function set(object, path, value) {
     const [nextProperty, ...rest] = path.split('.')
     if (rest.length === 0) {
         object[nextProperty] = value
-        return object
+        return
     }
     set(object[nextProperty], rest.join('.'), value)
-    return object
 }
 
 // with default options, will run 3 attempts, 1 at 0s, 1 at 500ms, 1 at 1000ms

--- a/packages/simulator/example.html
+++ b/packages/simulator/example.html
@@ -32,8 +32,8 @@
                 >"
             </div>
             <div>
-                Nested, type "<span x-text="typeof nested"></span>, value (stringified): "<span
-                    x-text="JSON.stringify(nested)"
+                Nested.array, type "<span x-text="typeof nested.array"></span>, value (stringified): "<span
+                    x-text="JSON.stringify(nested.array)"
                 ></span
                 >"
             </div>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,6 +75,17 @@ export default [
                         dest: 'dist/chrome',
                     },
                     {
+                        src: 'packages/shell-chrome/assets/panel.html',
+                        dest: 'dist/chrome',
+                        transform(contents) {
+                            // strip interpolated data-testids
+                            if (process.env.NODE_ENV === 'production') {
+                                return contents.toString().replace(/:data-testid="[^"]*"/g, '')
+                            }
+                            return contents.toString()
+                        },
+                    },
+                    {
                         src: 'packages/shell-chrome/assets/manifest.json',
                         dest: 'dist/chrome',
                         // inject version into manifest


### PR DESCRIPTION
One of the todo's of #86 

- fix input type for strings
- replace some `==` with `===`
- add tests for boolean, number and string editing

RFC: strip `:data-testid` bindings on production builds. Eventually might help with perf (fewer bindings to evaluate)... not sure it's necessary yet, thoughts?