### PR TITLE
Feature: inject component globals

### DIFF
--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -27,6 +27,7 @@ it('should create globals + add annotation for each component', () => {
         .then((componentCount) => {
             cy.get('[data-testid="console-global"]')
                 .should('contain.text', '= $x0')
+                .should('have.attr', 'title', 'Available as $x0 in the console')
                 .should('contain.text', '= $x1')
                 .should('contain.text', '= $x2')
                 .should('contain.text', '= $x3')

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -9,7 +9,7 @@ it('should get names of components', () => {
         .should('contain.text', 'combobox')
 })
 
-it('should create globals for each component', () => {
+it('should create globals + add annotation for each component', () => {
     let win
     cy.frameLoaded('#target').then(() => {
         win = cy.$$('#target').get(0).contentWindow
@@ -22,6 +22,16 @@ it('should create globals for each component', () => {
                 expect(win[`$x${i}`].$el).to.equal(component)
                 expect(win[`$x${i}`]).to.equal(component.__x)
             })
+            return components.length
+        })
+        .then((componentCount) => {
+            cy.get('[data-testid="console-global"]')
+                .should('contain.text', '= $x0')
+                .should('contain.text', '= $x1')
+                .should('contain.text', '= $x2')
+                .should('contain.text', '= $x3')
+                .should('contain.text', '= $x4')
+                .should('contain.text', `= $x${componentCount - 1}`)
         })
 })
 

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -9,6 +9,22 @@ it('should get names of components', () => {
         .should('contain.text', 'combobox')
 })
 
+it('should create globals for each component', () => {
+    let win
+    cy.frameLoaded('#target').then(() => {
+        win = cy.$$('#target').get(0).contentWindow
+    })
+
+    cy.iframe('#target')
+        .find('[x-data]')
+        .then((components) => {
+            components.each((i, component) => {
+                expect(win[`$x${i}`].$el).to.equal(component)
+                expect(win[`$x${i}`]).to.equal(component.__x)
+            })
+        })
+})
+
 it('should handle adding and removing new components', () => {
     cy.visit('/')
         .get('[data-testid=component-name]')

--- a/package-lock.json
+++ b/package-lock.json
@@ -3910,9 +3910,9 @@
       }
     },
     "cypress": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.0.1.tgz",
-      "integrity": "sha512-3xtQZ0YM65soLgKQUgn2wg2IbWsM6A2yBg6L4RF31mZHr5LNKdO2/9sgiwxEVMKu2C2m6+IQ75zHP41kZP5rPg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.1.0.tgz",
+      "integrity": "sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -4023,18 +4023,6 @@
             "strip-final-newline": "^2.0.0"
           }
         },
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
         "get-stream": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -4055,24 +4043,6 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
         },
         "npm-run-path": {
           "version": "4.0.1",
@@ -4112,12 +4082,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
         }
       }
     },
@@ -5127,12 +5091,12 @@
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
       }
     },
     "globals": {
@@ -5550,9 +5514,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@rollup/plugin-replace": "^2.3.4",
         "@tailwindcss/forms": "^0.2.1",
         "alpinejs": "^2.7.3",
-        "cypress": "^6.0.1",
+        "cypress": "^6.1.0",
         "cypress-iframe": "^1.0.1",
         "edge.js": "^1.1.4",
         "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
         }
     },
     "lint-staged": {
-        "*.{js,css,md,html}": "prettier --write"
+        "*.{js,css,md,html,edge}": "prettier --write"
     }
 }

--- a/packages/shell-chrome/views/_partials/component.edge
+++ b/packages/shell-chrome/views/_partials/component.edge
@@ -1,9 +1,9 @@
 @verbatim
 <a
     :class="{
-            'text-white bg-alpine-300' : component.isOpened,
-            'text-gray-600 hover:bg-blue-100' : !component.isOpened,
-        }"
+        'text-white bg-alpine-300' : component.isOpened,
+        'text-gray-600 hover:bg-blue-100' : !component.isOpened,
+    }"
     class="block cursor-pointer rounded"
     :style="`padding-left: ${component.depth * 20}px; `"
     @mouseenter="alpineState.hoverOnComponent(component)"
@@ -15,6 +15,9 @@
         <span class="opacity-25">&lt;</span>
         <span data-testid="component-name" x-text="component.name" class="text-base"></span>
         <span class="opacity-25">&gt;</span>
+        <div data-testid="console-global" class="text-white pl-2 text-xs" :title="`Available as $x${component.id} in the console`">
+            = <span x-text="`$x${component.id}`"></span>
+        </div>
     </h5>
 </a>
 @endverbatim

--- a/packages/shell-chrome/views/_partials/component.edge
+++ b/packages/shell-chrome/views/_partials/component.edge
@@ -2,7 +2,7 @@
 <a
     :class="{
         'text-white bg-alpine-300' : component.isOpened,
-        'text-gray-600 hover:bg-blue-100' : !component.isOpened,
+        'text-gray-600 hover:bg-blue-200' : !component.isOpened,
     }"
     class="block cursor-pointer rounded"
     :style="`padding-left: ${component.depth * 20}px; `"

--- a/packages/shell-chrome/views/_partials/component.edge
+++ b/packages/shell-chrome/views/_partials/component.edge
@@ -15,7 +15,11 @@
         <span class="opacity-25">&lt;</span>
         <span data-testid="component-name" x-text="component.name" class="text-base"></span>
         <span class="opacity-25">&gt;</span>
-        <div data-testid="console-global" class="text-white pl-2 text-xs" :title="`Available as $x${component.id} in the console`">
+        <div
+            data-testid="console-global"
+            class="text-white pl-2 text-xs"
+            :title="`Available as $x${component.id} in the console`"
+        >
             = <span x-text="`$x${component.id}`"></span>
         </div>
     </h5>


### PR DESCRIPTION
Closes #122 

- fixes a thing I typoed in #120 
- changes some `==` to `===`
- make id increment post assignment as id
- remove `observer` global and assign to `window.__alpineDevtool`

Create `$x0` - `$xN` (0-N is the component id)

<img width="640" alt="Screenshot 2020-12-14 at 20 53 29" src="https://user-images.githubusercontent.com/6459679/102136010-c0ed1200-3e50-11eb-948a-5116fe994529.png">
