### PR TITLE
Feature: add eval warnings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [HugoDF,KevinBatdorf,ryangjchandler]
+github: [HugoDF,KevinBatdorf,ryangjchandler,stephenoldham]

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -226,7 +226,9 @@ it('should display message with number of components watched', () => {
         .then((components) => {
             cy.get('[data-testid=footer-line]').then(($el) => {
                 expect($el.text()).to.contain('Watching')
-                expect($el.text()).to.contain(`${components.length} component(s)`)
+                expect($el.text()).to.contain(
+                    `${components.length} ${components.length > 1 ? 'components' : 'component'}`,
+                )
             })
         })
 })

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -224,6 +224,9 @@ it('should display message with number of components watched', () => {
         .get('[data-testid=component-name]')
         .should('have.length.above', 0)
         .then((components) => {
-            cy.get('[data-testid=footer-line]').should('contain', `Watching ${components.length} components`)
+            cy.get('[data-testid=footer-line]').then(($el) => {
+                expect($el.text()).to.contain('Watching')
+                expect($el.text()).to.contain(`${components.length} component(s)`)
+            })
         })
 })

--- a/cypress/integration/warning.js
+++ b/cypress/integration/warning.js
@@ -2,7 +2,7 @@ it('should display message with number of warnings', () => {
     cy.visit('/').get('[data-testid=component-name]').should('have.length.above', 0)
 
     cy.get('[data-testid=footer-line]').should(($el) => {
-        expect($el.text()).to.contain('0 warning(s)')
+        expect($el.text()).to.contain('0 warnings')
     })
 })
 it('should display "No Warnings" found', () => {
@@ -13,7 +13,7 @@ it('should catch component initialisation errors', () => {
     cy.iframe('#target').find('[data-testid=inject-broken]').click()
 
     cy.get('[data-testid=footer-line]').should(($el) => {
-        expect($el.text()).to.contain('1 warning(s)')
+        expect($el.text()).to.contain('1 warning')
     })
 
     cy.get('[data-testid=warnings-tab-content]').should('be.visible').should('not.contain.text', 'No warnings found')
@@ -24,7 +24,7 @@ it('should catch component initialisation errors', () => {
             const text = $el.text().replace(/\n/g, '')
             expect(text).to.contain(`Error evaluating`)
             expect(text).to.contain(`"{ foo: 'aaa' "`)
-            expect(text).to.contain(`"SyntaxError: Unexpected token ')'"`)
+            expect(text).to.contain(`SyntaxError: Unexpected token ')'`)
         })
 })
 it('should catch x-on errors', () => {
@@ -33,7 +33,7 @@ it('should catch x-on errors', () => {
     cy.get('[data-testid=eval-error-button]').should('have.length', 1)
 
     cy.get('[data-testid=footer-line]').should(($el) => {
-        expect($el.text()).to.contain('2 warning(s)')
+        expect($el.text()).to.contain('2 warnings')
     })
 
     cy.get('[data-testid=warnings-tab-content]').should('be.visible').should('not.contain.text', 'No warnings found')
@@ -42,7 +42,7 @@ it('should catch x-on errors', () => {
         const text = $el.text().replace(/\n/g, '')
         expect(text).to.contain(`Error evaluating`)
         expect(text).to.contain(`"foo.bar.baz"`)
-        expect(text).to.contain(`"ReferenceError: foo is not defined"`)
+        expect(text).to.contain(`ReferenceError: foo is not defined`)
     })
 })
 it('should scroll to newest error when warnings tab is open', () => {
@@ -53,7 +53,7 @@ it('should scroll to newest error when warnings tab is open', () => {
     cy.get('[data-testid=eval-error-button').should('have.length', 4)
 
     cy.get('[data-testid=footer-line]').should(($el) => {
-        expect($el.text()).to.contain('5 warning(s)')
+        expect($el.text()).to.contain('5 warnings')
     })
 
     cy.get('[data-testid=warnings-scroll-container]').should(($el) => {

--- a/cypress/integration/warning.js
+++ b/cypress/integration/warning.js
@@ -1,0 +1,91 @@
+it('should display message with number of warnings', () => {
+    cy.visit('/').get('[data-testid=component-name]').should('have.length.above', 0)
+
+    cy.get('[data-testid=footer-line]').should(($el) => {
+        expect($el.text()).to.contain('0 warning(s)')
+    })
+})
+it('should display "No Warnings" found', () => {
+    cy.get('[data-testid=tab-link-warnings').should('be.visible').click()
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible').should('contain.text', 'No warnings found')
+})
+it('should catch component initialisation errors', () => {
+    cy.iframe('#target').find('[data-testid=inject-broken]').click()
+
+    cy.get('[data-testid=footer-line]').should(($el) => {
+        expect($el.text()).to.contain('1 warning(s)')
+    })
+
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible').should('not.contain.text', 'No warnings found')
+
+    cy.get('[data-testid=eval-error-div]')
+        .should('have.length', 1)
+        .should(($el) => {
+            const text = $el.text().replace(/\n/g, '')
+            expect(text).to.contain(`Error evaluating`)
+            expect(text).to.contain(`"{ foo: 'aaa' "`)
+            expect(text).to.contain(`"SyntaxError: Unexpected token ')'"`)
+        })
+})
+it('should catch x-on errors', () => {
+    cy.iframe('#target').find('[data-testid=broken-click]').click()
+
+    cy.get('[data-testid=eval-error-button]').should('have.length', 1)
+
+    cy.get('[data-testid=footer-line]').should(($el) => {
+        expect($el.text()).to.contain('2 warning(s)')
+    })
+
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible').should('not.contain.text', 'No warnings found')
+
+    cy.get('[data-testid=eval-error-button]').should(($el) => {
+        const text = $el.text().replace(/\n/g, '')
+        expect(text).to.contain(`Error evaluating`)
+        expect(text).to.contain(`"foo.bar.baz"`)
+        expect(text).to.contain(`"ReferenceError: foo is not defined"`)
+    })
+})
+it('should scroll to newest error when warnings tab is open', () => {
+    cy.iframe('#target').find('[data-testid=broken-click]').click()
+    cy.iframe('#target').find('[data-testid=broken-click]').click()
+    cy.iframe('#target').find('[data-testid=broken-click]').click()
+
+    cy.get('[data-testid=eval-error-button').should('have.length', 4)
+
+    cy.get('[data-testid=footer-line]').should(($el) => {
+        expect($el.text()).to.contain('5 warning(s)')
+    })
+
+    cy.get('[data-testid=warnings-scroll-container]').should(($el) => {
+        expect($el.scrollTop()).not.to.equal(0)
+    })
+})
+
+it('should scroll to newest error when switching from components to warnings tab', () => {
+    cy.get('[data-testid=warnings-scroll-container]').scrollTo('top')
+    cy.get('[data-testid=warnings-scroll-container]').should(($el) => {
+        expect($el.scrollTop()).to.equal(0)
+    })
+
+    cy.get('[data-testid=tab-link-components]').click()
+    cy.get('[data-testid=warnings-tab-content]').should('not.be.visible')
+
+    cy.get('[data-testid=tab-link-warnings]').click()
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible')
+
+    cy.get('[data-testid=warnings-scroll-container]').should(($el) => {
+        expect($el.scrollTop()).not.to.equal(0)
+    })
+})
+
+it('footer links should toggle between components and warnings tab', () => {
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible')
+    cy.get('[data-testid=footer-components-link').click()
+    cy.get('[data-testid=warnings-tab-content]').should('not.be.visible')
+    cy.get('[data-testid=footer-warnings-link').click()
+    cy.get('[data-testid=warnings-tab-content]').should('be.visible')
+
+    cy.get('[data-testid=warnings-scroll-container]').should(($el) => {
+        expect($el.scrollTop()).not.to.equal(0)
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -3910,9 +3910,9 @@
       }
     },
     "cypress": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.1.0.tgz",
-      "integrity": "sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.3.0.tgz",
+      "integrity": "sha512-Ec6TAFOxdSB2HPINNJ1f7z75pENXcfCaQkz+A9j0eGSvusFJ2NNErq650DexCbNJAnCQkPqXB4XPH9kXnSQnUA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -5115,7 +5115,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -5832,6 +5833,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -8463,6 +8465,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8477,6 +8480,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -8485,7 +8489,8 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10147,9 +10152,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
       "dev": true
     },
     "pretty-format": {
@@ -11270,7 +11275,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@rollup/plugin-replace": "^2.3.4",
         "@tailwindcss/forms": "^0.2.1",
         "alpinejs": "^2.8.0",
-        "cypress": "^6.1.0",
+        "cypress": "^6.3.0",
         "cypress-iframe": "^1.0.1",
         "edge.js": "^1.1.4",
         "husky": "^4.3.0",

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -69,6 +69,7 @@ function init() {
             window.console.warn = this._realLogWarn
         }
         instrumentAlpineLogging() {
+            if (process.env.NODE_ENV === 'production') return
             if (!isRequiredVersion('2.8.0', window.Alpine.version) || !window.Alpine.version) {
                 return
             }

--- a/packages/shell-chrome/src/devtools/app.js
+++ b/packages/shell-chrome/src/devtools/app.js
@@ -9,15 +9,23 @@ export function init() {
 }
 
 export function handleMessage(message, port) {
+    /** @type {{alpineState: State}} */
+    const { alpineState } = window
     if (message.type === 'render-components') {
         // message.components is a serialised JSON string
-        window.alpineState.renderComponentsFromBackend(JSON.parse(message.components))
+        alpineState.renderComponentsFromBackend(JSON.parse(message.components))
 
         window.__alpineDevtool.port = port
     }
 
     if (message.type === 'set-version') {
-        window.alpineState.setAlpineVersionFromBackend(message.version)
+        alpineState.setAlpineVersionFromBackend(message.version)
+
+        window.__alpineDevtool.port = port
+    }
+
+    if (message.type === 'render-error') {
+        alpineState.renderError(message.error)
 
         window.__alpineDevtool.port = port
     }

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -76,6 +76,10 @@ export default function devtools() {
             )
         },
 
+        get isWarningsOverflowing() {
+            return this.$refs.warnings.scrollHeight > this.$refs.warnings.clientHeight
+        },
+
         get theme() {
             return this.themes[this.activeTheme]
         },

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -67,10 +67,6 @@ export default function devtools() {
             return this.version ? `v${this.version}` : '<v2.3.1'
         },
 
-        get footerText() {
-            return `Watching ${this.components.length} components`
-        },
-
         get openComponent() {
             return (
                 this.components.filter((component) => {

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -38,6 +38,7 @@ export default function devtools() {
         version: null,
         latest: null,
         components: [],
+        errors: [],
         showTools: false,
         showTimeout: 1500,
         activeTheme: 'dark-header',
@@ -79,8 +80,28 @@ export default function devtools() {
             return this.themes[this.activeTheme]
         },
 
+        scrollToLastError() {
+            // @todo add debounce
+            this.$nextTick(() => {
+                if (this.$refs.last_error) {
+                    this.$refs.last_error.scrollIntoView({
+                        behavior: 'smooth',
+                    })
+                }
+            })
+        },
+
         init() {
             this.initSplitPanes()
+
+            this.$watch('activeTab', (value) => {
+                if (value === 'warnings') {
+                    this.scrollToLastError()
+                }
+            })
+            this.$watch('errors', () => {
+                this.scrollToLastError()
+            })
 
             this.$watch('components', () => {
                 if (!this.showTools) {

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -3,6 +3,7 @@ import { flattenData, convertInputDataToType } from '../utils'
 export default class State {
     constructor() {
         this.components = {}
+        this.errors = []
         this.allDataAttributes = {}
         this.renderedComponentId = null
         this.version = {
@@ -67,6 +68,11 @@ export default class State {
         this.updateXdata()
     }
 
+    renderError(error) {
+        this.errors.push(error)
+        this.updateXdata()
+    }
+
     closeOpenedComponent() {
         if (this.renderedComponentId) {
             this.components[this.renderedComponentId].isOpened = false
@@ -124,6 +130,8 @@ export default class State {
         appData.version = this.version.detected
         appData.latest = this.version.latest
 
+        appData.errors = [...this.errors]
+
         appData.components = Object.values(this.components).sort(function (a, b) {
             return a.index - b.index
         })
@@ -135,6 +143,24 @@ export default class State {
             return true
         }
         return false
+    }
+
+    showErrorSource(errorId) {
+        if (this._hasNoDevtools('showErrorSource')) return
+        window.__alpineDevtool.port.postMessage({
+            errorId,
+            action: 'show-error-source',
+            source: 'alpineDevtool',
+        })
+    }
+
+    hideErrorSource(errorId) {
+        if (this._hasNoDevtools('hideErrorSource')) return
+        window.__alpineDevtool.port.postMessage({
+            errorId,
+            action: 'hide-error-source',
+            source: 'alpineDevtool',
+        })
     }
 
     hoverOnComponent(component) {

--- a/packages/shell-chrome/views/_components/tab-link.edge
+++ b/packages/shell-chrome/views/_components/tab-link.edge
@@ -5,6 +5,7 @@
         'text-white border-ice-500 cursor-default': activeTab === '{{ tab }}',
         'border-transparent hover:text-white hover:border-ice-700': activeTab !== '{{ tab }}',
     }"
+    data-testid="tab-link-{{ tab }}"
     class="px-4 border-b-3 xs:pl-2 xs:pr-3"
     @click.prevent="activeTab = '{{ tab }}'"
 >

--- a/packages/shell-chrome/views/_components/tab-link.edge
+++ b/packages/shell-chrome/views/_components/tab-link.edge
@@ -6,7 +6,7 @@
         'border-transparent hover:text-white hover:border-ice-700': activeTab !== '{{ tab }}',
     }"
     class="px-4 border-b-3 xs:pl-2 xs:pr-3"
-    @click="activeTab = '{{ tab }}'"
+    @click.prevent="activeTab = '{{ tab }}'"
 >
     @!yield($slot.main)
     <span class="hidden xs:inline-block">{{ label || upperFirst(tab) }}</span>

--- a/packages/shell-chrome/views/_partials/data/attribute.edge
+++ b/packages/shell-chrome/views/_partials/data/attribute.edge
@@ -23,7 +23,7 @@
             </div>
 
             <span
-                style="color: #881391"
+                class="text-purple"
                 x-text="singleData.attributeName"
                 :data-testid="`data-property-name-${singleData.attributeName}`"
             ></span>

--- a/packages/shell-chrome/views/_partials/footer.edge
+++ b/packages/shell-chrome/views/_partials/footer.edge
@@ -6,10 +6,29 @@
         <div class="flex items-center text-xs leading-9 font-medium font-mono">
             <div class="flex-1 pl-3" data-testid="footer-line">
                 Watching
-                <a href="#" data-testid="footer-components-link" @click.prevent="activeTab = 'components'"><span x-text="components.length"></span> component(s)</a>{{ devOnly ? ', ' : '' }}
-                @if(devOnly)
-                <a href="#" data-testid="footer-warnings-link" @click.prevent="activeTab = 'warnings'"><span x-text="errors.length"></span> warning(s)</a>
-                @endif
+                <div class="inline-flex">
+                    <a href="#" data-testid="footer-components-link" @click.prevent="activeTab = 'components'">
+                        @verbatim
+                        <span x-text="`${components.length} ${components.length > 1 || components.length == 0? 'components' : 'component'}`"></span>
+                        @endverbatim
+                    </a>
+                    
+                    @if(devOnly)
+                        ,&nbsp;
+                        <a 
+                            href="#" 
+                            data-testid="footer-warnings-link" 
+                            @click.prevent="activeTab = 'warnings'" 
+                            :class="{
+                                'text-red-400': errors.length > 0
+                            }"
+                        >
+                            @verbatim
+                            <span x-text="`${errors.length} ${errors.length > 1 || errors.length == 0? 'warnings' : 'warning'}`"></span>
+                            @endverbatim
+                        </a>
+                    @endif
+                </div>
             </div>
 
             @verbatim

--- a/packages/shell-chrome/views/_partials/footer.edge
+++ b/packages/shell-chrome/views/_partials/footer.edge
@@ -6,9 +6,9 @@
         <div class="flex items-center text-xs leading-9 font-medium font-mono">
             <div class="flex-1 pl-3" data-testid="footer-line">
                 Watching
-                <a href="#" @click.prevent="activeTab = 'components'"><span x-text="components.length"></span> component(s)</a>
+                <a href="#" data-testid="footer-components-link" @click.prevent="activeTab = 'components'"><span x-text="components.length"></span> component(s)</a>{{ devOnly ? ', ' : '' }}
                 @if(devOnly)
-                , <a href="#" @click.prevent="activeTab = 'warnings'"><span x-text="errors.length"></span> warning(s)</a>
+                <a href="#" data-testid="footer-warnings-link" @click.prevent="activeTab = 'warnings'"><span x-text="errors.length"></span> warning(s)</a>
                 @endif
             </div>
 

--- a/packages/shell-chrome/views/_partials/footer.edge
+++ b/packages/shell-chrome/views/_partials/footer.edge
@@ -4,11 +4,13 @@
 >
     <div class="flex-1">
         <div class="flex items-center text-xs leading-9 font-medium font-mono">
-            <div 
-                class="flex-1 pl-3" 
-                x-text="footerText"
-                data-testid="footer-line"
-            ></div>
+            <div class="flex-1 pl-3" data-testid="footer-line">
+                Watching
+                <a href="#" @click.prevent="activeTab = 'components'"><span x-text="components.length"></span> component(s)</a>
+                @if(devOnly)
+                , <a href="#" @click.prevent="activeTab = 'warnings'"><span x-text="errors.length"></span> warning(s)</a>
+                @endif
+            </div>
 
             @verbatim
             <div

--- a/packages/shell-chrome/views/_partials/tabs/warnings.edge
+++ b/packages/shell-chrome/views/_partials/tabs/warnings.edge
@@ -5,7 +5,7 @@
     class="grid h-full w-full overflow-hidden"
     data-testid="warnings-tab-content"
 >
-    <div class="flex-1 flex flex-col max-h-full overflow-scroll text-gray-600 bg-gray-100" data-testid="warnings-scroll-container">
+    <div x-ref="warnings" class="flex-1 flex flex-col max-h-full overflow-scroll text-gray-600" data-testid="warnings-scroll-container">
         <template x-if="showTools && errors.length === 0">
             <div
                 data-testid="no-warnings-message"
@@ -19,26 +19,51 @@
             <div>
                 <template x-for="(error, index) in errors" :key="error.errorId">
                     <div
-                        class="flex flex-col justify-center leading-7 font-mono whitespace-nowrap cursor-pointer"
+                        class="flex flex-col justify-center leading-6 text-gray-800 font-mono whitespace-nowrap cursor-pointer"
                         :x-ref="index === errors.length - 1 ? 'last_error' : ''"
                         @mouseenter="alpineState.showErrorSource(error.errorId)"
                         @mouseleave="alpineState.hideErrorSource(error.errorId)"
                     >
                         @verbatim
                         <template x-if="error.type === 'eval'">
-                            <div class="border-gray-300 border-b py-2 px-4" :data-testid="`eval-error-${error.source.name}`">
-                                <div class="flex">
-                                    <span class="text-base mr-2">Error evaluating</span>
-                                    <span class="text-base text-purple mr-2">
-                                        "<span x-text="error.expression"></span>"
-                                    </span>
-                                    <span class="mr-2">at</span>
-                                    <span class="opacity-25">&lt;</span>
-                                    <span data-testid="error-source" x-text="error.source.name" class="text-base"></span>
-                                    <span class="opacity-25">&gt;</span>
+                            <div 
+                            :class="{
+                                'border-b': !isWarningsOverflowing || (isWarningsOverflowing && index !== errors.length - 1)
+                            }"
+                            class="flex items-start border-gray-300 p-2 pr-3 bg-red-50 bg-opacity-50 hover:bg-yellow-50" :data-testid="`eval-error-${error.source.name}`">
+                                <div class="flex justify-center w-5 text-center mr-2">
+                                    <div class="inline-flex items-center justify-center w-3.5 h-3.5 mt-1 rounded-full text-white font-bold bg-red-500">
+                                        <svg class="inline-block w-full h-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <line x1="16" y1="8" x2="8" y2="16"></line><line x1="8" y1="8" x2="16" y2="16"></line>
+                                        </svg>
+                                    </div>
                                 </div>
-                                <div class="flex text-red-700">
-                                    "<span x-text="error.message"></span>"
+
+                                <div class="w-full">
+                                    <div class="flex text-sm space-x-2">
+                                        <div class="sm:flex-1">
+                                            Error evaluating "<span class="text-purple" x-text="error.expression"></span>"
+                                        </div>
+
+                                        <div 
+                                            class="flex"
+                                            @click="activeTab = 'componenets', alpineState.renderComponentData(component)"
+                                        >
+                                            <span class="sm:hidden">at&nbsp;</span>
+                                            <span class="opacity-25">&lt;</span>
+                                            <span data-testid="error-source" x-text="error.source.name" class=""></span>
+                                            <span class="opacity-25">&gt;</span>
+                                        </div>
+                                    </div>
+                                    <div class="flex text-sm">
+                                        <div class="mr-2">
+                                            <svg class="inline-block w-3.5 h-3.5 -mt-0.5 -ml-0.5 text-gray-900 text-opacity-25" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                                <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                            </svg>
+                                        </div>
+                                        <span class="text-red-700" x-text="error.message"></span>
+                                    </div>
                                 </div>
                             </div>
                         </template>

--- a/packages/shell-chrome/views/_partials/tabs/warnings.edge
+++ b/packages/shell-chrome/views/_partials/tabs/warnings.edge
@@ -1,0 +1,51 @@
+<div
+    :class="{
+        'opacity-75': !showTools,
+    }"
+    class="grid h-full w-full overflow-hidden"
+    data-testid="warnings-tab-content"
+>
+    <div class="flex-1 flex flex-col max-h-full overflow-scroll text-gray-600 bg-gray-100" data-testid="warnings-scroll-container">
+        <template x-if="showTools && errors.length === 0">
+            <div
+                data-testid="no-warnings-message"
+                class="flex flex-1 h-full w-full items-center justify-center p-4 text-gray-400 text-sm"
+            >
+                No warnings found
+            </div>
+        </template>
+
+        <template x-if="showTools && errors.length > 0">
+            <div>
+                <template x-for="(error, index) in errors" :key="error.errorId">
+                    <div
+                        class="flex flex-col justify-center leading-7 font-mono whitespace-nowrap cursor-pointer"
+                        :x-ref="index === errors.length - 1 ? 'last_error' : ''"
+                        @mouseenter="alpineState.showErrorSource(error.errorId)"
+                        @mouseleave="alpineState.hideErrorSource(error.errorId)"
+                    >
+                        @verbatim
+                        <template x-if="error.type === 'eval'">
+                            <div class="border-gray-300 border-b py-2 px-4" :data-testid="`eval-error-${error.source.name}`">
+                                <div class="flex">
+                                    <span class="text-base mr-2">Error evaluating</span>
+                                    <span class="text-base text-purple mr-2">
+                                        "<span x-text="error.expression"></span>"
+                                    </span>
+                                    <span class="mr-2">at</span>
+                                    <span class="opacity-25">&lt;</span>
+                                    <span data-testid="error-source" x-text="error.source.name" class="text-base"></span>
+                                    <span class="opacity-25">&gt;</span>
+                                </div>
+                                <div class="flex text-red-700">
+                                    "<span x-text="error.message"></span>"
+                                </div>
+                            </div>
+                        </template>
+                        @endverbatim
+                    </div>
+                </template>
+            </div>
+        </template>
+    </div>
+</div>

--- a/packages/shell-chrome/views/panel.edge
+++ b/packages/shell-chrome/views/panel.edge
@@ -30,10 +30,8 @@
                         </div>
                     </div>
 
-                    <div x-show="activeTab === 'warnings'" class="flex-1">
-                        <div class="flex h-full items-center justify-center text-gray-400 uppercase bg-gray-50">
-                            Warnings Tab
-                        </div>
+                    <div x-show="activeTab === 'warnings'" class="flex-1 overflow-hidden">
+                        @include('_partials.tabs.warnings')
                     </div>
                 @endif
 

--- a/packages/simulator/example.html
+++ b/packages/simulator/example.html
@@ -92,5 +92,13 @@
                 }
             }
         </script>
+        <button data-testid="inject-broken" onclick="injectBroken(event.target)">Inject broken component</button>
+
+        <script>
+            function injectBroken(target) {
+                target.insertAdjacentHTML('afterend', `<div x-data="{ foo: 'aaa' ">Broken x-data</div>`)
+            }
+        </script>
+        <button data-testid="broken-click" x-data x-on:click="foo.bar.baz">Broken x-on:click</button>
     </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
             colors: {
                 orange: colors.orange,
                 'cool-gray': colors.coolGray,
+                purple: '#881391',
                 alpine: {
                     100: '#7C87A2',
                     200: '#616D89',


### PR DESCRIPTION
Part 1 of #126

Changes:

- change footer text (`X component(s), X warning(s)`), make the text a link to the relevant tab
- intercept Alpine's warnings for eval errors
- implement initial UI for "Warnings" (only contains eval warnings)
- add/update tests

<img width="1280" alt="Screenshot 2021-01-09 at 16 49 11" src="https://user-images.githubusercontent.com/6459679/104103561-a2850580-529a-11eb-9375-3f68809da4bd.png">



Chore:
- move purple colour into Tailwind config
- prevent default on tab links
- upgrade Cypress

Needs feedback:
- do we need to debounce the "scroll to last element"?
- should we scroll to last element when changing tabs?
- thoughts on using `pauseMutationObserver`? @SimoTod 
- design feedback (one for @stephenoldham)
- should I take the `devOnly` checks out? (probably should if we're intending to roll this out, could be a separate PR)