### PR TITLE
remove tabs permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alpinejs-devtools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs-devtools",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "description": "DevTools extension for debugging Alpine.js applications.",
     "homepage": "https://github.com/alpine-collective/alpinejs-devtools",

--- a/packages/shell-chrome/assets/manifest.json
+++ b/packages/shell-chrome/assets/manifest.json
@@ -13,7 +13,7 @@
         "default_title": "Alpine.js devtools",
         "default_popup": "popups/not-found.html"
     },
-    "permissions": ["http://*/*", "https://*/*", "file:///*", "tabs"],
+    "permissions": ["http://*/*", "https://*/*", "file:///*"],
     "background": {
         "scripts": ["background.js"],
         "persistent": false


### PR DESCRIPTION
Follow up to #147 #149 
After raising a support ticket with Chrome Web Store, this was in their response

> Tabs permission is required when accessing title, url, pendingUrl and favIconUrl properties of tabs.

And this from the docs 🙈 should've "read the manual" (https://developer.chrome.com/docs/extensions/reference/tabs/#manifest)

> You can use most chrome.tabs methods and events without declaring any permissions in the extension's manifest file. However, if you require access to the url, pendingUrl, title, or favIconUrl properties