### PR TITLE
[poc]: poll for Alpine state updates

### DIFF
--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -59,6 +59,30 @@ export function set(object, path, value) {
     set(object[nextProperty], rest.join('.'), value)
 }
 
+/**
+ * Convert a serializable object into a sha256 hex digest
+ *
+ * @param {object} data
+ * @returns {Promise<string>}
+ */
+export async function digest(data) {
+    return hash(JSON.stringify(data))
+}
+
+/**
+ * SHA-256 hex digest of a string
+ *
+ * @param {string} string
+ * @returns {Promise<string>}
+ */
+async function hash(str) {
+    const msgUint8 = new TextEncoder().encode(str)
+    const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8)
+    const hashArray = Array.from(new Uint8Array(hashBuffer))
+    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+    return hashHex
+}
+
 // with default options, will run 3 attempts, 1 at 0s, 1 at 500ms, 1 at 1000ms
 // so should hook into Alpine.js if it loads within 1s of the script triggering
 export function waitForAlpine(cb, { maxAttempts = 3, interval = 500, delayFirstAttempt = false } = {}) {


### PR DESCRIPTION
Closes #151 

We need to hook into state updates.

Currently we've got a mutation observer (which means if the app re-renders, we'll update components), but there's no update hook for when eg. inputs are changed and that updates Alpine.js state.

I had a go at creating a new membrane for each component and wrapping the existing callback in a new membrane but that didn't seem to work too well. 

Maybe @ryangjchandler @SimoTod @KevinBatdorf would have a better idea than what this is: serialize the state, hash it, poll and compare the hash to see whether it has changed.