### PR TITLE
feat(global alpine errors)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2468,9 +2468,9 @@
       "dev": true
     },
     "alpinejs": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-2.8.0.tgz",
-      "integrity": "sha512-UHvE71BBYHJa6+RxjMwM0g4eokq+5yG1QO5C6VieUu0MVPlsUSlwvrh19VVZQApNIlQsgcvQUhIalzAIgoAPoA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-2.8.1.tgz",
+      "integrity": "sha512-ETJ/k0fbiBeP+OSd5Fhj70c+zb+YRzcVbyh5DVeLT3FBWMUeUvjOSWLi53IVLPSehaT2SKmB7w08WGF2jYTqNA==",
       "dev": true
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@rollup/plugin-node-resolve": "^7.1.3",
         "@rollup/plugin-replace": "^2.3.4",
         "@tailwindcss/forms": "^0.2.1",
-        "alpinejs": "^2.8.0",
+        "alpinejs": "^2.8.1",
         "cypress": "^6.3.0",
         "cypress-iframe": "^1.0.1",
         "edge.js": "^1.1.4",

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -75,25 +75,15 @@ function init() {
             }
             if (isRequiredVersion('2.8.1', window.Alpine.version)) {
                 window.addEventListener('error', (errorEvent) => {
-                    if (
-                        errorEvent.error &&
-                        errorEvent.error.el &&
-                        errorEvent.error.expression &&
-                        errorEvent.error.message
-                    ) {
-                        const { el, expression, message } = errorEvent.error
-                        this._handleAlpineError(el, expression, message)
+                    if (errorEvent.error && errorEvent.error.el && errorEvent.error.expression) {
+                        const { el, expression } = errorEvent.error
+                        this._handleAlpineError(el, expression, errorEvent.error.toString())
                     }
                 })
                 window.addEventListener('unhandledrejection', (rejectionEvent) => {
-                    if (
-                        rejectionEvent.reason &&
-                        rejectionEvent.reason.el &&
-                        rejectionEvent.reason.expression &&
-                        rejectionEvent.reason.message
-                    ) {
-                        const { el, expression, message } = rejectionEvent.reason
-                        this._handleAlpineError(el, expression, message)
+                    if (rejectionEvent.reason && rejectionEvent.reason.el && rejectionEvent.reason.expression) {
+                        const { el, expression } = rejectionEvent.reason
+                        this._handleAlpineError(el, expression, rejectionEvent.reason.toString())
                     }
                 })
                 return

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -70,7 +70,6 @@ function init() {
         }
 
         initAlpineErrorCollection() {
-            if (process.env.NODE_ENV === 'production') return
             if (!isRequiredVersion('2.8.0', window.Alpine.version) || !window.Alpine.version) {
                 return
             }
@@ -99,6 +98,7 @@ function init() {
                 })
                 return
             }
+
             this._realLogWarn = console.warn
 
             const instrumentedWarn = (...args) => {

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -60,6 +60,11 @@ export default function devtools() {
             return isRequiredVersion(this.latest, this.version)
         },
 
+        get canCollectErrors() {
+            if (!this.version || !this.latest) return null
+            return isRequiredVersion('2.8.0', this.version)
+        },
+
         get isLandscape() {
             return this.orientation === 'landscape'
         },

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -52,7 +52,6 @@ export default function devtools() {
         settingsPanelEnabled: process.env.NODE_ENV !== 'production',
         settingsPanelOpen: false,
 
-        tabsEnabled: process.env.NODE_ENV !== 'production',
         activeTab: 'components',
 
         get isLatest() {

--- a/packages/shell-chrome/views/_partials/footer.edge
+++ b/packages/shell-chrome/views/_partials/footer.edge
@@ -12,22 +12,19 @@
                         <span x-text="`${components.length} ${components.length > 1 || components.length == 0? 'components' : 'component'}`"></span>
                         @endverbatim
                     </a>
-                    
-                    @if(devOnly)
-                        ,&nbsp;
-                        <a 
-                            href="#" 
-                            data-testid="footer-warnings-link" 
-                            @click.prevent="activeTab = 'warnings'" 
-                            :class="{
-                                'text-red-400': errors.length > 0
-                            }"
-                        >
-                            @verbatim
-                            <span x-text="`${errors.length} ${errors.length > 1 || errors.length == 0? 'warnings' : 'warning'}`"></span>
-                            @endverbatim
-                        </a>
-                    @endif
+                    ,&nbsp;
+                    <a
+                        href="#"
+                        data-testid="footer-warnings-link"
+                        @click.prevent="activeTab = 'warnings'"
+                        :class="{
+                            'text-red-400': errors.length > 0
+                        }"
+                    >
+                        @verbatim
+                        <span x-text="`${errors.length} ${errors.length > 1 || errors.length == 0? 'warnings' : 'warning'}`"></span>
+                        @endverbatim
+                    </a>
                 </div>
             </div>
 

--- a/packages/shell-chrome/views/_partials/header.edge
+++ b/packages/shell-chrome/views/_partials/header.edge
@@ -54,58 +54,59 @@
         </div>
     </div>
 
-    @if(devOnly)
-        <div
-            :class="{
-            'opacity-0': !showTools,
-        }"
-            class="flex items-center text-sm text-ice-500 xs:space-x-3 pb-px transition"
-            style="line-height: 3.25rem"
+    <div
+        :class="{
+        'opacity-0': !showTools,
+    }"
+        class="flex items-center text-sm text-ice-500 xs:space-x-3 pb-px transition"
+        style="line-height: 3.25rem"
+    >
+        @set('iconClasses', 'inline-block w-6 h-6 xs:w-5 xs:h-5 xs:mr-0.5 xs:opacity-50')
+        @component('_components.tab-link', { tab: 'components' })
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="{{ iconClasses }}"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
         >
-            @set('iconClasses', 'inline-block w-6 h-6 xs:w-5 xs:h-5 xs:mr-0.5 xs:opacity-50')
-            @component('_components.tab-link', { tab: 'components' })
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="{{ iconClasses }}"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-            >
-                <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                />
-            </svg>
-            @endcomponent 
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+            />
+        </svg>
+        @endcomponent
 
-            @component('_components.tab-link', { tab: 'events' })
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="{{ iconClasses }}"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-            >
-                <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"
-                />
-            </svg>
-            @endcomponent 
 
-            @component('_components.tab-link', { tab: 'warnings' })
-            <svg xmlns="http://www.w3.org/2000/svg" class="{{ iconClasses }}" viewBox="0 0 20 20" fill="currentColor">
-                <path
-                    fill-rule="evenodd"
-                    d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-                    clip-rule="evenodd"
-                />
-            </svg>
-            @endcomponent
-        </div>
-    @endif
+        @if(devOnly)
+        @component('_components.tab-link', { tab: 'events' })
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="{{ iconClasses }}"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+        >
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"
+            />
+        </svg>
+        @endcomponent
+        @endif
+
+        @component('_components.tab-link', { tab: 'warnings' })
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ iconClasses }}" viewBox="0 0 20 20" fill="currentColor">
+            <path
+                fill-rule="evenodd"
+                d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+            />
+        </svg>
+        @endcomponent
+    </div>
 </div>

--- a/packages/shell-chrome/views/_partials/tabs/warnings.edge
+++ b/packages/shell-chrome/views/_partials/tabs/warnings.edge
@@ -6,12 +6,20 @@
     data-testid="warnings-tab-content"
 >
     <div x-ref="warnings" class="flex-1 flex flex-col max-h-full overflow-scroll text-gray-600" data-testid="warnings-scroll-container">
-        <template x-if="showTools && errors.length === 0">
+        <template x-if="canCollectErrors && showTools && errors.length === 0">
             <div
                 data-testid="no-warnings-message"
                 class="flex flex-1 h-full w-full items-center justify-center p-4 text-gray-400 text-sm"
             >
                 No warnings found
+            </div>
+        </template>
+        <template x-if="!canCollectErrors && showTools">
+            <div
+                data-testid="no-warnings-message"
+                class="flex flex-1 h-full w-full items-center justify-center p-4 text-gray-400 text-sm"
+            >
+                Warnings/Errors can't be collected for Alpine.js &lt;v2.8.0
             </div>
         </template>
 
@@ -26,7 +34,7 @@
                     >
                         @verbatim
                         <template x-if="error.type === 'eval'">
-                            <div 
+                            <div
                             :class="{
                                 'border-b': !isWarningsOverflowing || (isWarningsOverflowing && index !== errors.length - 1)
                             }"
@@ -45,7 +53,7 @@
                                             Error evaluating "<span class="text-purple" x-text="error.expression"></span>"
                                         </div>
 
-                                        <div 
+                                        <div
                                             class="flex"
                                             @click="activeTab = 'componenets', alpineState.renderComponentData(component)"
                                         >

--- a/packages/shell-chrome/views/panel.edge
+++ b/packages/shell-chrome/views/panel.edge
@@ -30,10 +30,11 @@
                         </div>
                     </div>
 
-                    <div x-show="activeTab === 'warnings'" class="flex-1 overflow-hidden">
-                        @include('_partials.tabs.warnings')
-                    </div>
                 @endif
+
+                <div x-show="activeTab === 'warnings'" class="flex-1 overflow-hidden">
+                    @include('_partials.tabs.warnings')
+                </div>
 
                 @include('_partials.footer')
 


### PR DESCRIPTION
Closes #126 
- Avoid patching `console.warn` when possible (Alpine.js attaches debug info to error/unhandledrejection's)
- remove `devOnly` flags for warnings tab
- add warning tab message when user is on Alpine <2.8.0
- upgrade Alpine.js to 2.8.1