### PR TITLE
feat perf(update-messaging)

### DIFF
--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -169,10 +169,10 @@ it('should display read-only function/HTMLElement attributes + allow editing of 
     // check they toggle off
     cy.get('[data-testid=data-property-value-el]').click()
 
-    cy.get('[data-testid=data-property-value-name]').should('not.be.visible')
+    cy.get('[data-testid=data-property-value-name]').should('not.exist')
 
-    cy.get('[data-testid=data-property-name-attributes]').should('not.be.visible')
-    cy.get('[data-testid=data-property-name-children]').should('not.be.visible')
+    cy.get('[data-testid=data-property-name-attributes]').should('not.exist')
+    cy.get('[data-testid=data-property-name-children]').should('not.exist')
 
     // booleans
     cy.get('[data-testid=data-property-name-bool]').should('be.visible').contains('bool')
@@ -232,32 +232,32 @@ it('should display nested arrays/object attributes and support editing', () => {
 
     cy.get('[data-testid=data-property-value-array]').click()
 
-    cy.get('[data-testid=data-property-name-0]').last().should('be.visible').contains('0')
-    cy.get('[data-testid=data-property-value-0]').last().should('be.visible').contains('Object')
+    cy.get('[data-testid=data-property-name-0]').should('be.visible').contains('0')
+    cy.get('[data-testid=data-property-value-0]').should('be.visible').contains('Object')
 
-    cy.get('[data-testid=data-property-name-0]').last().click()
+    cy.get('[data-testid=data-property-name-0]').click()
 
     cy.get('[data-testid=data-property-name-nested]').should('be.visible').contains('nested')
     cy.get('[data-testid=data-property-value-nested]').should('be.visible').contains('property')
 
     // check untoggling also works
-    cy.get('[data-testid=data-property-name-0]').last().click()
+    cy.get('[data-testid=data-property-name-0]').click()
 
-    cy.get('[data-testid=data-property-name-nested]').should('not.be.visible')
-    cy.get('[data-testid=data-property-value-nested]').should('not.be.visible')
+    cy.get('[data-testid=data-property-name-nested]').should('not.exist')
+    cy.get('[data-testid=data-property-value-nested]').should('not.exist')
 
     cy.get('[data-testid=data-property-value-array]').click()
 
-    cy.get('[data-testid=data-property-name-0]').last().should('not.be.visible')
-    cy.get('[data-testid=data-property-value-0]').last().should('not.be.visible')
+    cy.get('[data-testid=data-property-name-0]').should('not.exist')
+    cy.get('[data-testid=data-property-value-0]').should('not.exist')
 
     cy.get('[data-testid="data-property-value-nestedObjArr"]').click()
-    cy.get('[data-testid=data-property-name-array]').should('not.be.visible')
-    cy.get('[data-testid=data-property-value-array]').should('not.be.visible')
+    cy.get('[data-testid=data-property-name-array]').should('not.exist')
+    cy.get('[data-testid=data-property-value-array]').should('not.exist')
 
     cy.get('[data-testid="data-property-value-nestedObjArr"]').click()
     cy.get('[data-testid=data-property-value-array]').click()
-    cy.get('[data-testid=data-property-name-0]').last().click()
+    cy.get('[data-testid=data-property-name-0]').click()
     // editing the nested array/object
     cy.get('[data-testid=edit-icon-nested]').click({ force: true })
     cy.get('[data-testid=input-nested]')

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -303,3 +303,17 @@ it('should display message with number of components watched', () => {
             })
         })
 })
+
+it('should reset component selection when changing page', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid=component-name]').first().click()
+    cy.get('[data-testid=component-container]').first().should('have.class', 'text-white bg-alpine-300')
+
+    cy.get('[data-testid=data-property-name-myFunction]').should('be.visible').contains('myFunction')
+
+    cy.iframe('#target').find('[data-testid=navigation-target]').click()
+
+    cy.get('[data-testid=component-container]').first().should('not.have.class', 'text-white bg-alpine-300')
+    cy.get('[data-testid=data-property-name-myFunction]').should('not.exist')
+})

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -188,8 +188,10 @@ function init() {
                               }
 
                               if (el.contains(rootEl)) {
-                                  depth = depth + 1
+                                  return depth + 1
                               }
+
+                              return depth
                           }, 0)
 
                 return {

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -239,6 +239,11 @@ function init() {
         }
 
         handleGetComponentData(componentId) {
+            if (this.selectedComponentId === componentId) {
+                // component already loaded
+                // any changes to the component's data will be picked up by the mutation observer
+                return
+            }
             this.selectedComponentId = componentId
             this.runWithMutationPaused(() => {
                 Alpine.discoverComponents((component) => {

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -162,6 +162,7 @@ function init() {
                     return
                 }
 
+                // doesn't look like we need this
                 // Alpine.initializeComponent(rootEl)
 
                 if (!rootEl.__alpineDevtool) {

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -201,6 +201,7 @@ function init() {
 
             this._postMessage({
                 components: this.components,
+                url: btoa(window.location.href),
                 type: BACKEND_TO_PANEL_MESSAGES.SET_COMPONENTS,
             })
         }

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -202,14 +202,14 @@ function init() {
 
             this._postMessage({
                 components: this.components,
-                type: 'set-components',
+                type: BACKEND_TO_PANEL_MESSAGES.SET_COMPONENTS,
             })
         }
 
         getAlpineVersion() {
             this._postMessage({
                 version: window.Alpine.version,
-                type: 'set-version',
+                type: BACKEND_TO_PANEL_MESSAGES.SET_VERSION,
             })
         }
 
@@ -218,19 +218,6 @@ function init() {
                 {
                     source: 'alpine-devtools-backend',
                     payload,
-                },
-                '*',
-            )
-        }
-
-        getAlpineVersion() {
-            window.postMessage(
-                {
-                    source: 'alpine-devtools-backend',
-                    payload: {
-                        version: window.Alpine.version,
-                        type: 'set-version',
-                    },
                 },
                 '*',
             )

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -162,9 +162,6 @@ function init() {
                     return
                 }
 
-                // doesn't look like we need this
-                // Alpine.initializeComponent(rootEl)
-
                 if (!rootEl.__alpineDevtool) {
                     // add an attr to trigger the mutation observer and run this function
                     // that will send updated state to devtools

--- a/packages/shell-chrome/src/constants.js
+++ b/packages/shell-chrome/src/constants.js
@@ -3,10 +3,20 @@ export const DEVTOOLS_RENDER_BINDING_ATTR_NAME = `:${DEVTOOLS_RENDER_ATTR_NAME}`
 export const ADDED_ATTRIBUTES = [DEVTOOLS_RENDER_ATTR_NAME, DEVTOOLS_RENDER_BINDING_ATTR_NAME]
 
 export const BACKEND_TO_PANEL_MESSAGES = {
+    SET_VERSION: 'set-version',
     SET_COMPONENTS: 'set-components',
     SET_DATA: 'set-data',
+    ADD_ERROR: 'add-error',
 }
 
 export const PANEL_TO_BACKEND_MESSAGES = {
+    // shutdown is triggered from proxy.js
+    SHUTDOWN: 'shutdown',
+    // all other messages are triggered from devtools/state.js
     GET_DATA: 'get-data',
+    SHOW_ERROR_SOURCE: 'show-error-source',
+    HIDE_ERROR_SOURCE: 'hide-error-source',
+    HOVER_COMPONENT: 'hover',
+    HIDE_HOVER: 'hide-hover',
+    EDIT_ATTRIBUTE: 'edit-attribute',
 }

--- a/packages/shell-chrome/src/constants.js
+++ b/packages/shell-chrome/src/constants.js
@@ -1,3 +1,12 @@
 export const DEVTOOLS_RENDER_ATTR_NAME = 'data-devtools-render'
 export const DEVTOOLS_RENDER_BINDING_ATTR_NAME = `:${DEVTOOLS_RENDER_ATTR_NAME}`
 export const ADDED_ATTRIBUTES = [DEVTOOLS_RENDER_ATTR_NAME, DEVTOOLS_RENDER_BINDING_ATTR_NAME]
+
+export const BACKEND_TO_PANEL_MESSAGES = {
+    SET_COMPONENTS: 'set-components',
+    SET_DATA: 'set-data',
+}
+
+export const PANEL_TO_BACKEND_MESSAGES = {
+    GET_DATA: 'get-data',
+}

--- a/packages/shell-chrome/src/devtools/app.js
+++ b/packages/shell-chrome/src/devtools/app.js
@@ -1,6 +1,7 @@
 /* Extension API-agnostic application setup */
 import State from './state'
 import devtools from './devtools'
+import { BACKEND_TO_PANEL_MESSAGES } from '../constants'
 
 export function init() {
     window.__alpineDevtool = {}
@@ -8,31 +9,31 @@ export function init() {
     window.devtools = devtools
 }
 
+function setPort(port) {
+    window.__alpineDevtool.port = port
+}
+
 export function handleMessage(message, port) {
     /** @type {{alpineState: State}} */
     const { alpineState } = window
 
-    if (message.type === 'set-components') {
+    if (message.type === BACKEND_TO_PANEL_MESSAGES.SET_COMPONENTS) {
         alpineState.setComponentsList(message.components)
-
-        window.__alpineDevtool.port = port
+        setPort(port)
     }
 
-    if (message.type === 'set-data') {
+    if (message.type === BACKEND_TO_PANEL_MESSAGES.SET_DATA) {
         alpineState.setComponentData(message.componentId, JSON.parse(message.data))
-
-        window.__alpineDevtool.port = port
+        setPort(port)
     }
 
-    if (message.type === 'set-version') {
+    if (message.type === BACKEND_TO_PANEL_MESSAGES.SET_VERSION) {
         alpineState.setAlpineVersionFromBackend(message.version)
-
-        window.__alpineDevtool.port = port
+        setPort(port)
     }
 
-    if (message.type === 'render-error') {
+    if (message.type === BACKEND_TO_PANEL_MESSAGES.ADD_ERROR) {
         alpineState.renderError(message.error)
-
-        window.__alpineDevtool.port = port
+        setPort(port)
     }
 }

--- a/packages/shell-chrome/src/devtools/app.js
+++ b/packages/shell-chrome/src/devtools/app.js
@@ -18,7 +18,7 @@ export function handleMessage(message, port) {
     const { alpineState } = window
 
     if (message.type === BACKEND_TO_PANEL_MESSAGES.SET_COMPONENTS) {
-        alpineState.setComponentsList(message.components)
+        alpineState.setComponentsList(message.components, message.url)
         setPort(port)
     }
 

--- a/packages/shell-chrome/src/devtools/app.js
+++ b/packages/shell-chrome/src/devtools/app.js
@@ -12,14 +12,6 @@ export function handleMessage(message, port) {
     /** @type {{alpineState: State}} */
     const { alpineState } = window
 
-    // @todo remove this
-    if (message.type === 'render-components') {
-        // message.components is a serialised JSON string
-        alpineState.renderComponentsFromBackend(JSON.parse(message.components))
-
-        window.__alpineDevtool.port = port
-    }
-
     if (message.type === 'set-components') {
         alpineState.setComponentsList(message.components)
 

--- a/packages/shell-chrome/src/devtools/app.js
+++ b/packages/shell-chrome/src/devtools/app.js
@@ -11,9 +11,23 @@ export function init() {
 export function handleMessage(message, port) {
     /** @type {{alpineState: State}} */
     const { alpineState } = window
+
+    // @todo remove this
     if (message.type === 'render-components') {
         // message.components is a serialised JSON string
         alpineState.renderComponentsFromBackend(JSON.parse(message.components))
+
+        window.__alpineDevtool.port = port
+    }
+
+    if (message.type === 'set-components') {
+        alpineState.setComponentsList(message.components)
+
+        window.__alpineDevtool.port = port
+    }
+
+    if (message.type === 'set-data') {
+        alpineState.setComponentData(message.componentId, JSON.parse(message.data))
 
         window.__alpineDevtool.port = port
     }

--- a/packages/shell-chrome/src/devtools/devtools.js
+++ b/packages/shell-chrome/src/devtools/devtools.js
@@ -37,6 +37,8 @@ export default function devtools() {
     return {
         version: null,
         latest: null,
+        selectedComponentFlattenedData: null,
+        openComponent: null,
         components: [],
         errors: [],
         showTools: false,
@@ -70,14 +72,6 @@ export default function devtools() {
 
         get detected() {
             return this.version ? `v${this.version}` : '<v2.3.1'
-        },
-
-        get openComponent() {
-            return (
-                this.components.filter((component) => {
-                    return component.isOpened
-                })[0] || {}
-            )
         },
 
         get isWarningsOverflowing() {

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -12,6 +12,7 @@ const unavailablePortShim = {
 
 export default class State {
     constructor() {
+        this.appUrl = null
         this.components = {}
         this.errors = []
         this.allDataAttributes = {}
@@ -28,13 +29,20 @@ export default class State {
         return window.__alpineDevtool.port || unavailablePortShim
     }
 
-    setComponentsList(components) {
+    setComponentsList(components, appUrl) {
         this.checkForRemovedComponents(components)
         components.forEach((component, index) => {
             component.index = index
             component.isOpened = this.selectedComponentId === component.id
             this.components[component.id] = component
         })
+
+        if (appUrl !== this.appUrl || !components.find((c) => c.id === this.selectedComponentId)) {
+            this.selectedComponentId = null
+            this.preloadedComponentData = {}
+            this.selectedComponentFlattenedData = null
+            this.appUrl = appUrl
+        }
 
         this.updateDevtoolsXData()
     }
@@ -176,10 +184,10 @@ export default class State {
 
         if (this.selectedComponentId && this.preloadedComponentData[this.selectedComponentId]) {
             this.selectedComponentFlattenedData = this.preloadedComponentData[this.selectedComponentId]
-
-            appData.selectedComponentFlattenedData = this.selectedComponentFlattenedData
-            appData.openComponent = this.components[this.selectedComponentId] || null
         }
+
+        appData.selectedComponentFlattenedData = this.selectedComponentFlattenedData
+        appData.openComponent = this.components[this.selectedComponentId] || null
     }
 
     showErrorSource(errorId) {

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -20,7 +20,7 @@ export default class State {
             this.components[component.id] = component
         })
 
-        this.updateXdata()
+        this.updateDevtoolsXData()
     }
 
     setComponentData(componentId, data) {
@@ -69,57 +69,12 @@ export default class State {
 
         this.selectedComponentFlattenedData = flattenedData
         this.renderedComponentId = componentId
-        this.updateXdata()
-    }
-
-    // @todo remove this
-    renderComponentsFromBackend(components) {
-        this.checkForRemovedComponents(components)
-
-        components.forEach((component, index) => {
-            component.index = index
-            component.isOpened = this.renderedComponentId == component.id
-
-            component.flattenedData = flattenData(component.data)
-
-            component.flattenedData.forEach((d) => {
-                if (
-                    (this.allDataAttributes[component.id] &&
-                        this.allDataAttributes[component.id][d.id] &&
-                        this.allDataAttributes[component.id][d.id].isOpened) ||
-                    (d.directParentId.length &&
-                        this.allDataAttributes[component.id][d.directParentId] &&
-                        this.allDataAttributes[component.id][d.directParentId].isArrowDown)
-                ) {
-                    d.isOpened = true
-                }
-
-                if (
-                    this.allDataAttributes[component.id] &&
-                    this.allDataAttributes[component.id][d.id] &&
-                    this.allDataAttributes[component.id][d.id].hasArrow
-                ) {
-                    d.isArrowDown = this.allDataAttributes[component.id][d.id].isArrowDown
-                }
-
-                d.parentComponentId = component.id
-
-                if (!this.allDataAttributes[component.id]) {
-                    this.allDataAttributes[component.id] = {}
-                }
-
-                this.allDataAttributes[component.id][d.id] = d
-            })
-
-            this.components[component.id] = component
-        })
-
-        this.updateXdata()
+        this.updateDevtoolsXData()
     }
 
     setAlpineVersionFromBackend(version) {
         this.version.detected = version
-        this.updateXdata()
+        this.updateDevtoolsXData()
     }
 
     renderComponentData(component) {
@@ -135,12 +90,12 @@ export default class State {
             })
         }
 
-        this.updateXdata()
+        this.updateDevtoolsXData()
     }
 
     renderError(error) {
         this.errors.push(error)
-        this.updateXdata()
+        this.updateDevtoolsXData()
     }
 
     closeOpenedComponent() {
@@ -190,11 +145,11 @@ export default class State {
                 }
             })
 
-            this.updateXdata()
+            this.updateDevtoolsXData()
         }
     }
 
-    updateXdata() {
+    updateDevtoolsXData() {
         let appData = document.getElementById('app').__x.$data
 
         appData.version = this.version.detected

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -1,4 +1,7 @@
 import { flattenData, convertInputDataToType } from '../utils'
+import { PANEL_TO_BACKEND_MESSAGES } from '../constants'
+
+const ALPINE_DEVTOOL_SOURCE = 'alpineDevtool'
 
 export default class State {
     constructor() {
@@ -176,8 +179,8 @@ export default class State {
         if (this._hasNoDevtools('showErrorSource')) return
         window.__alpineDevtool.port.postMessage({
             errorId,
-            action: 'show-error-source',
-            source: 'alpineDevtool',
+            action: PANEL_TO_BACKEND_MESSAGES.SHOW_ERROR_SOURCE,
+            source: ALPINE_DEVTOOL_SOURCE,
         })
     }
 
@@ -185,8 +188,8 @@ export default class State {
         if (this._hasNoDevtools('hideErrorSource')) return
         window.__alpineDevtool.port.postMessage({
             errorId,
-            action: 'hide-error-source',
-            source: 'alpineDevtool',
+            action: PANEL_TO_BACKEND_MESSAGES.HIDE_ERROR_SOURCE,
+            source: ALPINE_DEVTOOL_SOURCE,
         })
     }
 
@@ -194,8 +197,8 @@ export default class State {
         if (this._hasNoDevtools('hoverOnComponent')) return
         window.__alpineDevtool.port.postMessage({
             componentId: component.id,
-            action: 'hover',
-            source: 'alpineDevtool',
+            action: PANEL_TO_BACKEND_MESSAGES.HOVER_COMPONENT,
+            source: ALPINE_DEVTOOL_SOURCE,
         })
 
         // pre-load component
@@ -210,8 +213,8 @@ export default class State {
         if (this._hasNoDevtools('hoverLeftComponent')) return
         window.__alpineDevtool.port.postMessage({
             componentId: component.id,
-            action: 'hoverLeft',
-            source: 'alpineDevtool',
+            action: PANEL_TO_BACKEND_MESSAGES.HIDE_HOVER,
+            source: ALPINE_DEVTOOL_SOURCE,
         })
     }
 
@@ -238,8 +241,8 @@ export default class State {
             componentId: clickedAttribute.parentComponentId,
             attributeSequence: clickedAttribute.id,
             attributeValue: clickedAttribute.attributeValue,
-            action: 'editAttribute',
-            source: 'alpineDevtool',
+            action: PANEL_TO_BACKEND_MESSAGES.EDIT_ATTRIBUTE,
+            source: ALPINE_DEVTOOL_SOURCE,
         })
     }
 

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -191,7 +191,7 @@ export function flattenSingleAttribute(
         inputType: mapDataTypeToInputType(type),
         id: generatedId,
         inEditingMode: false,
-        isOpened: id.length == 0,
+        isOpened: id.length === 0,
         isArrowDown: false,
         directParentId: directParentId,
     })

--- a/packages/shell-chrome/views/_partials/component.edge
+++ b/packages/shell-chrome/views/_partials/component.edge
@@ -1,8 +1,8 @@
 @verbatim
 <a
     :class="{
-        'text-white bg-alpine-300': component.isOpened,
-        'text-gray-600 hover:bg-blue-200': !component.isOpened,
+        'text-white bg-alpine-300': openComponent && component.isOpened,
+        'text-gray-600 hover:bg-blue-200': !openComponent || !component.isOpened,
     }"
     class="block cursor-pointer rounded"
     :style="`padding-left: ${component.depth * 20}px; `"

--- a/packages/shell-chrome/views/_partials/data/attribute.edge
+++ b/packages/shell-chrome/views/_partials/data/attribute.edge
@@ -1,131 +1,135 @@
 @verbatim
 <div class="group flex items-center">
-    <a
-        :style="`margin-left: ${singleData.depth}px;`"
-        @click="alpineState.toggleDataAttribute(singleData)"
-        class="block px-1 rounded hover:bg-blue-100"
-        :class="{
-            'cursor-pointer': singleData.hasArrow
-        }"
-        x-show="singleData.depth === 0 || singleData.isOpened"
-    >
-        <h5 data-testid="data-property" class="flex items-center relative pl-3 leading-6 text-sm whitespace-nowrap">
-            <div class="absolute left-0 h-full flex items-center">
-                <span
-                    x-show="singleData.hasArrow"
-                    class="arrow"
-                    :data-testid="singleData.isArrowDown ? 'arrow-down' : 'arrow-right'"
-                    :class="{
-                            'right': !singleData.isArrowDown,
-                            'down': singleData.isArrowDown
-                        }"
-                ></span>
-            </div>
-
-            <span
-                class="text-purple"
-                x-text="singleData.attributeName"
-                :data-testid="`data-property-name-${singleData.attributeName}`"
-            ></span>
-
-            <span class="text-black">:</span>
-
-            <div
-                :data-testid="`data-property-value-${singleData.attributeName}`"
-                class="text-black ml-1"
-                x-show="!singleData.inEditingMode"
-            >
-                <template x-if="singleData.dataType === 'string'">
-                    <div>
-                        &quot;<span class="text-red-700" x-text="singleData.attributeValue"></span>&quot;
-                    </div>
-                </template>
-
-                <template x-if="singleData.dataType === 'boolean'">
-                    <div class="flex items-center">
-                        <span
-                            class="block pr-1 text-blue-700 cursor-pointer"
-                            x-text="singleData.attributeValue"
-                            @click="singleData.editAttributeValue = !singleData.editAttributeValue, $nextTick(() => alpineState.saveEditing(singleData))"
-                        ></span>
-
-                        <input
-                            type="checkbox"
-                            x-model="singleData.editAttributeValue"
-                            @change.stop="$nextTick(() => alpineState.saveEditing(singleData))"
-                            class="focus:ring-transparent h-4 w-4 text-blue-700 border-gray-300 cursor-pointer rounded transition duration-150 ease-in-out opacity-0 group-hover:opacity-100"
-                        />
-                    </div>
-                </template>
-
-                <template x-if="!['string', 'boolean'].includes(singleData.dataType)">
-                    <a
-                        :href="singleData.attributeValue === 'Unserializable Value' ? 'https://github.com/alpine-collective/alpinejs-devtools/discussions/new' : null "
-                        :title="singleData.attributeValue === 'Unserializable Value' ? 'Click to report this unserializable value' : null"
-                        x-text="singleData.attributeValue"
-                    ></a>
-                </template>
-            </div>
-        </h5>
-    </a>
-
-    <div
-        class="flex flex-col"
-        x-show="!singleData.hasArrow && !singleData.readOnly && (singleData.depth === 0 || singleData.isOpened)"
-    >
-        <svg
-            fill="currentColor"
-            x-show="!singleData.inEditingMode && singleData.dataType !== 'boolean'"
-            :data-testid="`edit-icon-${singleData.attributeName}`"
-            @click="alpineState.editAttribute(singleData)"
-            viewBox="0 0 20 20"
-            class="w-4 h-4 cursor-pointer opacity-0 group-hover:opacity-100 hover:opacity-75"
+    <template x-if="singleData.depth === 0 || singleData.isOpened">
+        <a
+            :style="`margin-left: ${singleData.depth}px;`"
+            @click="alpineState.toggleDataAttribute(singleData)"
+            class="block px-1 rounded hover:bg-blue-100"
+            :class="{
+                'cursor-pointer': singleData.hasArrow
+            }"
         >
-            <path
-                d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-            ></path>
-        </svg>
+            <h5 data-testid="data-property" class="flex items-center relative pl-3 leading-6 text-sm whitespace-nowrap">
+                <div class="absolute left-0 h-full flex items-center">
+                    <template x-if="singleData.hasArrow">
+                        <span
+                            class="arrow"
+                            :data-testid="singleData.isArrowDown ? 'arrow-down' : 'arrow-right'"
+                            :class="{
+                                    'right': !singleData.isArrowDown,
+                                    'down': singleData.isArrowDown
+                                }"
+                        ></span>
+                    </template>
+                </div>
 
-        <template x-if="singleData.dataType !== 'boolean'">
-            <div x-show="singleData.inEditingMode" class="flex flex-row items-center">
-                <input
-                    @keydown.enter.stop="alpineState.saveEditing(singleData)"
-                    @keydown.escape.stop="alpineState.cancelEditing(singleData)"
-                    class="flex text-gray-700 leading-tight focus:outline-none focus:ring w-2/3 shadow appearance-none border rounded py-1 px-1"
-                    :type="singleData.inputType"
-                    :data-testid="`input-${singleData.attributeName}`"
-                    x-model="singleData.editAttributeValue"
-                />
+                <span
+                    class="text-purple"
+                    x-text="singleData.attributeName"
+                    :data-testid="`data-property-name-${singleData.attributeName}`"
+                ></span>
 
+                <span class="text-black">:</span>
+
+                <div
+                    :data-testid="`data-property-value-${singleData.attributeName}`"
+                    class="text-black ml-1"
+                    x-show="!singleData.inEditingMode"
+                >
+                    <template x-if="singleData.dataType === 'string'">
+                        <div>
+                            &quot;<span class="text-red-700" x-text="singleData.attributeValue"></span>&quot;
+                        </div>
+                    </template>
+
+                    <template x-if="singleData.dataType === 'boolean'">
+                        <div class="flex items-center">
+                            <span
+                                class="block pr-1 text-blue-700 cursor-pointer"
+                                x-text="singleData.attributeValue"
+                                @click="singleData.editAttributeValue = !singleData.editAttributeValue; alpineState.saveEditing(singleData)"
+                            ></span>
+
+                            <input
+                                type="checkbox"
+                                x-model="singleData.editAttributeValue"
+                                @change.stop="alpineState.saveEditing(singleData)"
+                                class="focus:ring-transparent h-4 w-4 text-blue-700 border-gray-300 cursor-pointer rounded transition duration-150 ease-in-out opacity-0 group-hover:opacity-100"
+                            />
+                        </div>
+                    </template>
+
+                    <template x-if="!['string', 'boolean'].includes(singleData.dataType)">
+                        <a
+                            :href="singleData.attributeValue === 'Unserializable Value' ? 'https://github.com/alpine-collective/alpinejs-devtools/discussions/new' : null "
+                            :title="singleData.attributeValue === 'Unserializable Value' ? 'Click to report this unserializable value' : null"
+                            x-text="singleData.attributeValue"
+                        ></a>
+                    </template>
+                </div>
+            </h5>
+        </a>
+    </template>
+
+    <template x-if="!singleData.hasArrow && !singleData.readOnly && (singleData.depth === 0 || singleData.isOpened)">
+        <div
+            class="flex flex-col"
+        >
+            <template x-if="!singleData.inEditingMode && singleData.dataType !== 'boolean'">
                 <svg
                     fill="currentColor"
-                    data-testid="save-icon"
-                    @click="alpineState.saveEditing(singleData)"
+                    :data-testid="`edit-icon-${singleData.attributeName}`"
+                    @click="alpineState.editAttribute(singleData)"
                     viewBox="0 0 20 20"
-                    class="flex w-5 h-5 cursor-pointer ml-2 hover:opacity-75"
+                    class="w-4 h-4 cursor-pointer opacity-0 group-hover:opacity-100 hover:opacity-75"
                 >
                     <path
-                        fill-rule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                        clip-rule="evenodd"
+                        d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
                     ></path>
                 </svg>
+            </template>
 
-                <svg
-                    fill="currentColor"
-                    data-testid="cancel-icon"
-                    @click="alpineState.cancelEditing(singleData)"
-                    viewBox="0 0 20 20"
-                    class="flex w-5 h-5 ml-1 cursor-pointer hover:opacity-75"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                        clip-rule="evenodd"
-                    ></path>
-                </svg>
-            </div>
-        </template>
-    </div>
+            <template x-if="singleData.dataType !== 'boolean'">
+                <div x-show="singleData.inEditingMode" class="flex flex-row items-center">
+                    <input
+                        @keydown.enter.stop="alpineState.saveEditing(singleData)"
+                        @keydown.escape.stop="alpineState.cancelEditing(singleData)"
+                        class="flex text-gray-700 leading-tight focus:outline-none focus:ring w-2/3 shadow appearance-none border rounded py-1 px-1"
+                        :type="singleData.inputType"
+                        :data-testid="`input-${singleData.attributeName}`"
+                        x-model="singleData.editAttributeValue"
+                    />
+
+                    <svg
+                        fill="currentColor"
+                        data-testid="save-icon"
+                        @click="alpineState.saveEditing(singleData)"
+                        viewBox="0 0 20 20"
+                        class="flex w-5 h-5 cursor-pointer ml-2 hover:opacity-75"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                            clip-rule="evenodd"
+                        ></path>
+                    </svg>
+
+                    <svg
+                        fill="currentColor"
+                        data-testid="cancel-icon"
+                        @click="alpineState.cancelEditing(singleData)"
+                        viewBox="0 0 20 20"
+                        class="flex w-5 h-5 ml-1 cursor-pointer hover:opacity-75"
+                    >
+                        <path
+                            fill-rule="evenodd"
+                            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                            clip-rule="evenodd"
+                        ></path>
+                    </svg>
+                </div>
+            </template>
+        </div>
+    </template>
 </div>
 @endverbatim

--- a/packages/shell-chrome/views/_partials/data/attribute.edge
+++ b/packages/shell-chrome/views/_partials/data/attribute.edge
@@ -1,13 +1,13 @@
 @verbatim
 <div class="group flex items-center">
     <a
-        :style="`margin-left: ${singleData.depth}px; `"
+        :style="`margin-left: ${singleData.depth}px;`"
         @click="alpineState.toggleDataAttribute(singleData)"
         class="block px-1 rounded hover:bg-blue-100"
         :class="{
-                'cursor-pointer': singleData.hasArrow
-            }"
-        x-show="singleData.isOpened"
+            'cursor-pointer': singleData.hasArrow
+        }"
+        x-show="singleData.depth === 0 || singleData.isOpened"
     >
         <h5 data-testid="data-property" class="flex items-center relative pl-3 leading-6 text-sm whitespace-nowrap">
             <div class="absolute left-0 h-full flex items-center">
@@ -36,10 +36,12 @@
                 x-show="!singleData.inEditingMode"
             >
                 <template x-if="singleData.dataType === 'string'">
-                    &quot;<span class="text-red-700" x-text="singleData.attributeValue"></span>&quot;
+                    <div>
+                        &quot;<span class="text-red-700" x-text="singleData.attributeValue"></span>&quot;
+                    </div>
                 </template>
 
-                <template x-if="singleData.dataType == 'boolean'">
+                <template x-if="singleData.dataType === 'boolean'">
                     <div class="flex items-center">
                         <span
                             class="block pr-1 text-blue-700 cursor-pointer"
@@ -69,14 +71,11 @@
 
     <div
         class="flex flex-col"
-        x-show="!singleData.hasArrow
-            && !singleData.readOnly
-            && singleData.isOpened"
+        x-show="!singleData.hasArrow && !singleData.readOnly && (singleData.depth === 0 || singleData.isOpened)"
     >
         <svg
             fill="currentColor"
-            x-show="!singleData.inEditingMode
-                && singleData.dataType !== 'boolean'"
+            x-show="!singleData.inEditingMode && singleData.dataType !== 'boolean'"
             :data-testid="`edit-icon-${singleData.attributeName}`"
             @click="alpineState.editAttribute(singleData)"
             viewBox="0 0 20 20"

--- a/packages/shell-chrome/views/_partials/tabs/components.edge
+++ b/packages/shell-chrome/views/_partials/tabs/components.edge
@@ -34,7 +34,7 @@
 
     <!-- Active Component/Data -->
     <div class="flex-1 relative flex flex-col max-h-full overflow-scroll">
-        <template x-if="openComponent.name">
+        <template x-if="openComponent">
             <div
                 class="sticky top-0 left-0 z-20 w-full flex items-center px-3 py-2 text-base font-mono text-gray-600 bg-gray-100"
             >
@@ -44,7 +44,7 @@
             </div>
         </template>
 
-        <template x-if="!openComponent.name">
+        <template x-if="!openComponent">
             <div
                 data-testid="select-component-message"
                 x-text="showTools && components.length > 0 ? 'Select a component to view' : ''"
@@ -54,23 +54,21 @@
 
         <div
             :class="{
-            'hidden': !showTools || !openComponent.name,
+            'hidden': !showTools || !openComponent,
         }"
             class="flex-1 px-3 py-2"
         >
-            <template x-for="(singleComponent, componentIndex) in components">
-                <div x-show="singleComponent.isOpened" class="font-mono">
-                    <div class="leading-6 text-gray-300">x-data: {</div>
-
+        <div class="font-mono">
+            <div class="leading-6 text-gray-300">x-data: {</div>
+                <template x-if="selectedComponentFlattenedData">
                     <div>
-                        <template x-for="(singleData, index) in singleComponent.flattenedData">
+                        <template x-for="(singleData, index) in selectedComponentFlattenedData">
                             @include('_partials.data.attribute')
                         </template>
                     </div>
-
-                    <div class="leading-7 text-gray-300">}</div>
-                </div>
-            </template>
+                </template>
+            <div class="leading-7 text-gray-300">}</div>
+        </div>
         </div>
     </div>
 </div>

--- a/packages/simulator/example.html
+++ b/packages/simulator/example.html
@@ -112,5 +112,8 @@
             }
         </script>
         <button data-testid="broken-click" x-data x-on:click="foo.bar.baz">Broken x-on:click</button>
+        <div>
+            <a data-testid="navigation-target" href="/navigation-target.html">Go to next page</a>
+        </div>
     </body>
 </html>

--- a/packages/simulator/navigation-target.html
+++ b/packages/simulator/navigation-target.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Alpine.js Devtools Example</title>
+        <!-- <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script> -->
+        <!-- Rollup server is configured to serve contents of node_modules/alpinejs/dist, see rollup.config.js -->
+        <!-- Uncomment the following script to use that version, eg. when working offline -->
+        <script src="/alpine.js" defer></script>
+    </head>
+
+    <body>
+        <div id="app" x-data="{ hello: 'world' }">
+            <span x-text="hello"></span>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Closes #174 

Closes #10 the perf limitation doesn't seem to be the user's DOM, looping through the components is much faster if we don't do anything with the component data, opened a separate performance issue to optimise loading of components with lots of data -> #179

Todo:

- [x] snappier loading of data (send message to load data on hover of the component, display it on click)
- [x] tidy up of message name constants
- [x] remove old messages/methods
- [x] testing with nested components (might need to be a separate PR for tests that goes in beforehand) #178 
- [x] test on alpinetoolbox.com and compare perf, perf for load is much better, perf for clicking the component is worse (we trigger 2 messages)
- [x] deduplicate "get-data" messages when receiving them in the backend
- [x] figure out if we need the commented out `Alpine.initializeComponent(rootEl)`, edit: we don't need it, we short-circuit if `__x` is missing, and in the case where `el.__x` is present, `initializeComponent` does nothing, see https://github.com/alpinejs/alpine/blob/master/src/index.js#L89-L99

## Performance comparison

### Before 

Panel load is in tens of seconds, (using latest published Devtools version `v0.3.0`)

![devtools-v0-3-0](https://user-images.githubusercontent.com/6459679/110923249-9956fa00-8318-11eb-9c1b-1103e495b4b2.gif)

### After 

Panel load feels almost instant (using a prod build from this PR)

![devtools-next](https://user-images.githubusercontent.com/6459679/110923279-9fe57180-8318-11eb-948e-139b426de25d.gif)
