### PR TITLE
chore(ci-node-14)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     env:
       CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,6 @@ jobs:
     - run: npx cypress install && npx cypress cache list
     - uses: cypress-io/github-action@v2
       with:
-        start: npm start
+        start: npm run start:ci
         command: npm run cy:run
         install: false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Unlike other frameworks, Alpine does not include named components. Therefore by 
 
 ## Development
 
+### Prerequisites
+
+-   Node ^14.x
+-   npm ^6.x
+
 ### Chrome
 
 1. Clone this repo

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "homepage": "https://github.com/alpine-collective/alpinejs-devtools",
     "scripts": {
         "start": "rollup -c -w",
+        "start:ci": "ROLLUP_SERVE=true rollup -c",
         "build:dev": "rollup -c",
         "build": "NODE_ENV=production rollup -c",
         "watch": "npm start",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,7 +48,7 @@ const JS_INPUTS = [
 ]
 
 const MIXED_INPUT = ['packages/shell-chrome/src/devtools/panel.js']
-if (isWatch) {
+if (shouldServe) {
     MIXED_INPUT.push('packages/simulator/dev.js')
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,7 @@ import { renderPanel } from './lib/edge/render'
 renderPanel()
 
 const isWatch = process.env.ROLLUP_WATCH === 'true'
+const shouldServe = process.env.ROLLUP_SERVE === 'true' || isWatch
 if (isWatch) {
     fs.watch('./packages/shell-chrome/assets', { recursive: true }, (_event, filename) => {
         try {
@@ -99,7 +100,7 @@ export default [
                 ],
             }),
             filesize(),
-            isWatch &&
+            shouldServe &&
                 serve({
                     port: process.env.PORT || 8080,
                     contentBase: ['./dist/chrome', './packages/simulator', './node_modules/alpinejs/dist'],


### PR DESCRIPTION
Switch to Node 14 to run CI: Node 12 is now is "Maintenance LTS", Node 14 is "Active LTS" 
Add a note in the README.
Add "start:ci" that runs the server without watching for changes.