### PR TITLE
fix(maintain-open-attribute) fix(track-selected-id-on-other-hover-no-click)

### DIFF
--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -271,7 +271,7 @@ it('should display nested arrays/object attributes and support editing', () => {
         .should('have.text', JSON.stringify({ array: [{ nested: 'from-devtools' }] }))
 })
 
-it.only('should support x-model updates and editing values', () => {
+it('should support x-model updates and editing values', () => {
     cy.visit('/').get('[data-testid=component-name]').should('be.visible')
 
     cy.get('[data-testid=component-name]').contains('model-no-render').click().trigger('mouseleave')
@@ -292,6 +292,24 @@ it.only('should support x-model updates and editing values', () => {
         .click({ force: true })
 
     cy.iframe('#target').find('[data-testid=model-no-render]').should('have.value', 'from-devtools')
+
+    // nested updates
+    cy.get('[data-testid=data-property-name-model]').click()
+    cy.get('[data-testid=data-property-name-nested').should('be.visible').contains('nested')
+    cy.get('[data-testid=data-property-value-nested').should('be.visible').contains('nested-initial')
+
+    cy.iframe('#target').find('[data-testid=nested-model-no-render]').clear().type('nested-update')
+    cy.get('[data-testid=data-property-name-nested').should('be.visible').contains('nested')
+    cy.get('[data-testid=data-property-value-nested').should('be.visible').contains('nested-update')
+
+    cy.get('[data-testid=edit-icon-nested]').click({ force: true })
+    cy.get('[data-testid=input-nested]')
+        .clear({ force: true })
+        .type('nested-from-devtools', { force: true })
+        .siblings('[data-testid=save-icon]')
+        .click({ force: true })
+
+    cy.iframe('#target').find('[data-testid=nested-model-no-render]').should('have.value', 'nested-from-devtools')
 })
 
 it('should display message with number of components watched', () => {

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -240,6 +240,18 @@ it('should display nested arrays/object attributes and support editing', () => {
     cy.get('[data-testid=data-property-name-nested]').should('be.visible').contains('nested')
     cy.get('[data-testid=data-property-value-nested]').should('be.visible').contains('property')
 
+    // editing the nested array/object
+    cy.get('[data-testid=edit-icon-nested]').click({ force: true })
+    cy.get('[data-testid=input-nested]')
+        .clear({ force: true })
+        .type('from-devtools', { force: true })
+        .siblings('[data-testid=save-icon]')
+        .click({ force: true })
+
+    cy.iframe('#target')
+        .find('[data-testid=nested-obj-arr]')
+        .should('have.text', JSON.stringify({ array: [{ nested: 'from-devtools' }] }))
+
     // check untoggling also works
     cy.get('[data-testid=data-property-name-0]').click()
 
@@ -258,17 +270,6 @@ it('should display nested arrays/object attributes and support editing', () => {
     cy.get('[data-testid="data-property-value-nestedObjArr"]').click()
     cy.get('[data-testid=data-property-value-array]').click()
     cy.get('[data-testid=data-property-name-0]').click()
-    // editing the nested array/object
-    cy.get('[data-testid=edit-icon-nested]').click({ force: true })
-    cy.get('[data-testid=input-nested]')
-        .clear({ force: true })
-        .type('from-devtools', { force: true })
-        .siblings('[data-testid=save-icon]')
-        .click({ force: true })
-
-    cy.iframe('#target')
-        .find('[data-testid=nested-obj-arr]')
-        .should('have.text', JSON.stringify({ array: [{ nested: 'from-devtools' }] }))
 })
 
 it('should support x-model updates and editing values', () => {

--- a/cypress/integration/component.js
+++ b/cypress/integration/component.js
@@ -271,10 +271,14 @@ it('should display nested arrays/object attributes and support editing', () => {
         .should('have.text', JSON.stringify({ array: [{ nested: 'from-devtools' }] }))
 })
 
-it('should support x-model updates (even without a re-render) and editing values', () => {
+it.only('should support x-model updates and editing values', () => {
     cy.visit('/').get('[data-testid=component-name]').should('be.visible')
 
     cy.get('[data-testid=component-name]').contains('model-no-render').click().trigger('mouseleave')
+
+    // check preloading doesn't cause issues with selected component tracking
+    cy.get('[data-testid=component-name]').last().trigger('mouseenter').trigger('mouseleave')
+
     cy.get('[data-testid=data-property-name-text]').should('be.visible').contains('text')
     cy.get('[data-testid=data-property-value-text]').should('be.visible').contains('initial')
     cy.iframe('#target').find('[data-testid=model-no-render]').should('be.visible').clear().type('updated')

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -124,7 +124,7 @@ export default class State {
 
     toggleDataAttribute(attribute) {
         if (attribute.hasArrow) {
-            let childrenIdLength = attribute.id.split('.').length + 1
+            const childrenIdLength = attribute.id.split('.').length + 1
 
             // this code generate something like that \\w+\\.\\w+\\.\\w+$
             let closeRegexStr = ''
@@ -135,13 +135,10 @@ export default class State {
 
             closeRegexStr += String.raw`\w+$`
 
-            let closeRegex = new RegExp(closeRegexStr)
+            const closeRegex = new RegExp(closeRegexStr)
 
             const childrenAttributesIds = this.selectedComponentFlattenedData
                 .filter((attr) => {
-                    if (attr.parentComponentId !== attribute.parentComponentId) {
-                        return false
-                    }
                     const { id } = attr
                     if (attribute.isArrowDown) {
                         return id.startsWith(attribute.id) && id !== attribute.id && closeRegex.test(id)

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -137,16 +137,18 @@ export default class State {
 
             let closeRegex = new RegExp(closeRegexStr)
 
-            let childrenAttributesIds = this.selectedComponentFlattenedData
-                .filter((attr) => attr.parentComponentId === attribute.parentComponentId)
-                .map((attr) => attr.id)
-                .filter((a) => {
-                    if (attribute.isArrowDown) {
-                        return a.startsWith(attribute.id) && a != attribute.id && closeRegex.test(a)
+            const childrenAttributesIds = this.selectedComponentFlattenedData
+                .filter((attr) => {
+                    if (attr.parentComponentId !== attribute.parentComponentId) {
+                        return false
                     }
-
-                    return a.startsWith(`${attribute.id}.`) && a.split('.').length === childrenIdLength
+                    const { id } = attr
+                    if (attribute.isArrowDown) {
+                        return id.startsWith(attribute.id) && id !== attribute.id && closeRegex.test(id)
+                    }
+                    return id.startsWith(`${attribute.id}.`) && id.split('.').length === childrenIdLength
                 })
+                .map((attr) => attr.id)
 
             childrenAttributesIds.forEach((childId) => {
                 this.selectedComponentFlattenedData.forEach((d) => {

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -231,6 +231,11 @@ export default class State {
             action: PANEL_TO_BACKEND_MESSAGES.HIDE_HOVER,
             source: ALPINE_DEVTOOL_SOURCE,
         })
+
+        if (this.selectedComponentId && component.id !== this.selectedComponentId) {
+            // undo component preload when hovering away without clicking
+            this.triggerComponentDataLoad(this.selectedComponentId)
+        }
     }
 
     editAttribute(clickedAttribute) {

--- a/packages/shell-chrome/src/devtools/state.js
+++ b/packages/shell-chrome/src/devtools/state.js
@@ -58,7 +58,8 @@ export default class State {
                   }, {})
                 : {}
 
-            let isOpened = false
+            // top-level attributes should be open
+            let isOpened = d.depth === 0
             if (
                 (prevDataAttributeState[componentId] &&
                     prevDataAttributeState[componentId][d.id] &&
@@ -68,6 +69,7 @@ export default class State {
                     prevDataAttributeState[componentId][d.directParentId] &&
                     prevDataAttributeState[componentId][d.directParentId].isArrowDown)
             ) {
+                // maintain previous open state
                 isOpened = true
             }
 

--- a/packages/shell-chrome/views/_partials/data/attribute.edge
+++ b/packages/shell-chrome/views/_partials/data/attribute.edge
@@ -1,6 +1,6 @@
 @verbatim
 <div class="group flex items-center">
-    <template x-if="singleData.depth === 0 || singleData.isOpened">
+    <template x-if="singleData.isOpened">
         <a
             :style="`margin-left: ${singleData.depth}px;`"
             @click="alpineState.toggleDataAttribute(singleData)"
@@ -71,7 +71,7 @@
         </a>
     </template>
 
-    <template x-if="!singleData.hasArrow && !singleData.readOnly && (singleData.depth === 0 || singleData.isOpened)">
+    <template x-if="!singleData.hasArrow && !singleData.readOnly && singleData.isOpened">
         <div
             class="flex flex-col"
         >

--- a/packages/simulator/example.html
+++ b/packages/simulator/example.html
@@ -61,10 +61,14 @@
                 <div x-data x-title="nested2">Nesting 2</div>
             </div>
         </div>
-        <div x-title="model-no-render" x-data="{ text: 'initial' }">
+        <div x-title="model-no-render" x-data="{ text: 'initial', model: { nested: 'nested-initial' } }">
             <label>
                 Doesn't re-render but has x-model
                 <input type="text" x-model="text" data-testid="model-no-render" />
+            </label>
+            <label>
+                x-model on nested value
+                <input type="text" x-model="model.nested" data-testid="nested-model-no-render" />
             </label>
         </div>
         <button


### PR DESCRIPTION
Follow-up for #174 

Fixes:
- maintain attribute "open" state across component data updates
- receive updates for selected component if you hover without clicking another one