### PR TITLE
fix(add-panel-globals-before-injecting-backend)

### DIFF
--- a/packages/shell-chrome/src/devtools/panel.js
+++ b/packages/shell-chrome/src/devtools/panel.js
@@ -2,9 +2,9 @@
 import { init, handleMessage } from './app'
 
 function connect() {
-    injectScript(chrome.runtime.getURL('./backend.js'), () => {
-        init()
+    init()
 
+    injectScript(chrome.runtime.getURL('./backend.js'), () => {
         const port = chrome.runtime.connect({
             name: '' + chrome.devtools.inspectedWindow.tabId,
         })


### PR DESCRIPTION
Fixes issue where panel crashes due to 'devtools' being undefined